### PR TITLE
fix(payments): solved issue when creating a payment from a cart that contains both a customer id and an anonymous id

### DIFF
--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -176,9 +176,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
           id: ctCart.customerId,
         },
       }),
-      ...(ctCart.anonymousId && {
-        anonymousId: ctCart.anonymousId,
-      }),
+      ...(!ctCart.customerId &&
+        ctCart.anonymousId && {
+          anonymousId: ctCart.anonymousId,
+        }),
     });
 
     const updatedCart = await this.ctCartService.addPayment({

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -241,9 +241,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
             id: ctCart.customerId,
           },
         }),
-        ...(ctCart.anonymousId && {
-          anonymousId: ctCart.anonymousId,
-        }),
+        ...(!ctCart.customerId &&
+          ctCart.anonymousId && {
+            anonymousId: ctCart.anonymousId,
+          }),
       });
 
       ctCart = await this.ctCartService.addPayment({


### PR DESCRIPTION
An error was happening in the payment connectors when trying to create a payment and the cart was anonymous and later the customer signed-in or signed-up so, in summary, the cart contains 2 references, one to a customer id and one to an anonymous id.
Following exception caused the issue: 

```
{
    "statusCode": 400,
    "message": "The anonymousId 'idString' was already used for sign-in or sign-up.",
    "errors": [
        {
            "code": "InvalidOperation",
            "message": "The anonymousId 'idString' was already used for sign-in or sign-up."
        }
    ]
}
```

The issue has been solved by assigning only one customer reference to the payment, either the customer id or the anonymous id, having preference the customer id over the anonymous id.

More details in: https://commercetools.atlassian.net/browse/SCC-2292