### PR TITLE
Support terms and conditions error on paypal and googlepay methods

### DIFF
--- a/enabler/src/components/payment-methods/applepay.ts
+++ b/enabler/src/components/payment-methods/applepay.ts
@@ -55,7 +55,15 @@ export class ApplePayComponent extends DefaultAdyenComponent {
 
   init() {
     this.component = this.adyenCheckout.create(this.paymentMethod, {
-      ...this.componentOptions,
+      showPayButton: this.componentOptions.showPayButton,
+      onClick: (resolve, reject) => {
+        if (this.componentOptions.onPayButtonClick) {
+          return this.componentOptions.onPayButtonClick()
+            .then(() => resolve())
+            .catch((error) => reject(error));
+        } 
+        return resolve();
+      },
       buttonType: "pay",
       buttonColor: "black",
       ...(this.usesOwnCertificate && {

--- a/enabler/src/components/payment-methods/googlepay.ts
+++ b/enabler/src/components/payment-methods/googlepay.ts
@@ -45,12 +45,12 @@ export class GooglePayComponent extends DefaultAdyenComponent {
     this.component = this.adyenCheckout.create(this.paymentMethod, {
       showPayButton: this.componentOptions.showPayButton,
       onClick: (resolve, reject) => {
-        const res = this.componentOptions.onClick();
-        if (res instanceof Promise) {
-          res.then(() => resolve()).catch((error) => reject(error));
-        } else {
-          resolve();
-        }
+        if (this.componentOptions.onPayButtonClick) {
+          return this.componentOptions.onPayButtonClick()
+            .then(() => resolve())
+            .catch((error) => reject(error));
+        } 
+        return resolve();
       },
       buttonType: 'pay',
       buttonSizeMode: 'fill'

--- a/enabler/src/components/payment-methods/googlepay.ts
+++ b/enabler/src/components/payment-methods/googlepay.ts
@@ -43,7 +43,15 @@ export class GooglePayComponent extends DefaultAdyenComponent {
 
   init() {
     this.component = this.adyenCheckout.create(this.paymentMethod, {
-      ...this.componentOptions,
+      showPayButton: this.componentOptions.showPayButton,
+      onClick: (resolve, reject) => {
+        const res = this.componentOptions.onClick();
+        if (res instanceof Promise) {
+          res.then(() => resolve()).catch((error) => reject(error));
+        } else {
+          resolve();
+        }
+      },
       buttonType: 'pay',
       buttonSizeMode: 'fill'
     })

--- a/enabler/src/components/payment-methods/paypal.ts
+++ b/enabler/src/components/payment-methods/paypal.ts
@@ -51,12 +51,12 @@ export class PaypalComponent extends DefaultAdyenComponent {
     this.component = this.adyenCheckout.create(this.paymentMethod, {
       showPayButton: this.componentOptions.showPayButton,
       onClick: (_, {resolve, reject}) => {
-        const res = this.componentOptions.onClick();
-        if (res instanceof Promise) {
-          res.then(() => resolve()).catch((error) => reject(error));
-        } else {
-          resolve();
-        }
+        if (this.componentOptions.onPayButtonClick) {
+          return this.componentOptions.onPayButtonClick()
+            .then(() => resolve())
+            .catch((error) => reject(error));
+        } 
+        return resolve();
       },
       blockPayPalCreditButton: true,
       blockPayPalPayLaterButton: true,

--- a/enabler/src/components/payment-methods/paypal.ts
+++ b/enabler/src/components/payment-methods/paypal.ts
@@ -49,7 +49,15 @@ export class PaypalComponent extends DefaultAdyenComponent {
 
   init() {
     this.component = this.adyenCheckout.create(this.paymentMethod, {
-      ...this.componentOptions,
+      showPayButton: this.componentOptions.showPayButton,
+      onClick: (_, {resolve, reject}) => {
+        const res = this.componentOptions.onClick();
+        if (res instanceof Promise) {
+          res.then(() => resolve()).catch((error) => reject(error));
+        } else {
+          resolve();
+        }
+      },
       blockPayPalCreditButton: true,
       blockPayPalPayLaterButton: true,
       blockPayPalVenmoButton: true,

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -42,7 +42,7 @@ export type PaymentResult = {
 
 export type ComponentOptions = {
   showPayButton?: boolean;
-  onClick?: () => boolean | Promise<void>;
+  onPayButtonClick?: () => Promise<void>;
 };
 
 export interface PaymentEnabler {

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -42,7 +42,7 @@ export type PaymentResult = {
 
 export type ComponentOptions = {
   showPayButton?: boolean;
-  onClick?: () => boolean;
+  onClick?: () => boolean | Promise<void>;
 };
 
 export interface PaymentEnabler {


### PR DESCRIPTION
It looks like `onClick` has a different signature on both methods:

For Googlepay it receives `resolve` and `reject` as the first and second param

For Paypal the second param is an object containing `resolve` and `reject`

