### PR TITLE
feat(adyen): expose isAvailable

### DIFF
--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -88,17 +88,22 @@ export class DefaultAdyenComponent implements PaymentComponent {
   }
 
   mount(selector: string) {
+   this.component.mount(selector);
+  }
+
+  isAvailable() {
     if ("isAvailable" in this.component) {
-      this.component
-        .isAvailable()
-        .then(() => {
-          this.component.mount(selector);
-        })
-        .catch((e: unknown) => {
-          console.log(`${this.paymentMethod} is not available`, e);
-        });
+      return this.component.isAvailable()
+      .then(() => {
+        console.log(`${this.paymentMethod} is available`);
+        return true;
+      })
+      .catch((e: unknown) => {
+        console.log(`${this.paymentMethod} is not available`, e);
+        return false;
+      });
     } else {
-      this.component.mount(selector);
+      return Promise.resolve(true);
     }
   }
 }

--- a/enabler/src/components/payment-methods/applepay.ts
+++ b/enabler/src/components/payment-methods/applepay.ts
@@ -95,16 +95,4 @@ export class ApplePayComponent extends DefaultAdyenComponent {
         reject(error);
       });
   }
-
-  isAvailable() {
-    return this.component.isAvailable()
-    .then(() => {
-      console.log(`${this.paymentMethod} is available`);
-      return true;
-    })
-    .catch((e: unknown) => {
-      console.log(`${this.paymentMethod} is not available`, e);
-      return false;
-    });
-  }
 }

--- a/enabler/src/components/payment-methods/applepay.ts
+++ b/enabler/src/components/payment-methods/applepay.ts
@@ -95,4 +95,16 @@ export class ApplePayComponent extends DefaultAdyenComponent {
         reject(error);
       });
   }
+
+  isAvailable() {
+    return this.component.isAvailable()
+    .then(() => {
+      console.log(`${this.paymentMethod} is available`);
+      return true;
+    })
+    .catch((e: unknown) => {
+      console.log(`${this.paymentMethod} is not available`, e);
+      return false;
+    });
+  }
 }

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -10,6 +10,7 @@ export interface PaymentComponent {
       expiryDate?: string;
     }
   };
+  isAvailable?(): Promise<boolean>;
 }
 
 export interface PaymentComponentBuilder {


### PR DESCRIPTION
See Jira: https://commercetools.atlassian.net/browse/SCC-2362

This PR exposes the `isAvailable` method for Adyen so we can control when payment methods should and should not be rendered in the checkout. It uses Adyen's isAvailable helper.


Edit: 
see below, Apple Pay is rendered in Safari but not in Chrome

| Safari | Chrome |
|--------|--------|
| ![image](https://github.com/commercetools/connect-payment-integration-adyen/assets/17336834/6f8b6fb4-4350-46e6-8271-86ca246c7f9b) | ![image (1)](https://github.com/commercetools/connect-payment-integration-adyen/assets/17336834/c6cc2685-cfaf-4544-9509-e6cc6375e0d7) | 

