### PR TITLE
feat(klarna): remove the componentHasSubmit for all Klarna options

### DIFF
--- a/enabler/src/components/payment-methods/klarna-pay-later.ts
+++ b/enabler/src/components/payment-methods/klarna-pay-later.ts
@@ -17,7 +17,6 @@ import {
  * https://docs.adyen.com/payment-methods/klarna/web-component/
  */
 export class KlarnaPayLaterBuilder extends AdyenBaseComponentBuilder {
-  public componentHasSubmit = false;
 
   constructor(baseOptions: BaseOptions) {
     super(PaymentMethod.klarna, baseOptions);

--- a/enabler/src/components/payment-methods/klarna-pay-now.ts
+++ b/enabler/src/components/payment-methods/klarna-pay-now.ts
@@ -17,7 +17,6 @@ import {
  * https://docs.adyen.com/payment-methods/klarna/web-component/
  */
 export class KlarnaPayNowBuilder extends AdyenBaseComponentBuilder {
-  public componentHasSubmit = false;
 
   constructor(baseOptions: BaseOptions) {
     super(PaymentMethod.klarna_paynow, baseOptions);

--- a/enabler/src/components/payment-methods/klarna-pay-over-time.ts
+++ b/enabler/src/components/payment-methods/klarna-pay-over-time.ts
@@ -17,7 +17,6 @@ import {
  * https://docs.adyen.com/payment-methods/klarna/web-component/
  */
 export class KlarnaPayOverTimeBuilder extends AdyenBaseComponentBuilder {
-  public componentHasSubmit = false;
 
   constructor(baseOptions: BaseOptions) {
     super(PaymentMethod.klarna_account, baseOptions);


### PR DESCRIPTION
### Related tickets:
1. [SCC-2251](https://commercetools.atlassian.net/browse/SCC-2251)
2. [SCC-2252](https://commercetools.atlassian.net/browse/SCC-2252)
3. [SCC-2253](https://commercetools.atlassian.net/browse/SCC-2253)

As a followup on https://github.com/commercetools/connect-payment-integration-adyen/pull/129 for Klarna the componentHasSubmit needs to have the value of `true` (which is the default value).