### PR TITLE
feat(processor): send line items to Adyen for capture payments if payment-method requires it

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@adyen/api-library": "17.1.0",
         "@commercetools-backend/loggers": "22.27.0",
-        "@commercetools/connect-payments-sdk": "0.7.0",
+        "@commercetools/connect-payments-sdk": "0.8.0",
         "@fastify/autoload": "5.8.3",
         "@fastify/cors": "9.0.1",
         "@fastify/formbody": "7.4.0",
@@ -847,12 +847,12 @@
       }
     },
     "node_modules/@commercetools/connect-payments-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.7.0.tgz",
-      "integrity": "sha512-RrdJwxnDwxYyaAsuKUoAujr2ABx6ln1hiTMz0FRY9fI38aQdXTjDJkGVBQmqWJ9baxLPveRBj+GpsdtDOLcvGg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.0.tgz",
+      "integrity": "sha512-xQYDN2aQkGLn8oeTKuK/VQZfiZLer3n6lsOyl+6Cr4pTxhDH4BdciXvo1FdCZZEpisV69v6cHWC8JZ2kI4WaZw==",
       "dependencies": {
         "@commercetools-backend/loggers": "22.27.0",
-        "@commercetools/platform-sdk": "7.8.0",
+        "@commercetools/platform-sdk": "7.9.0",
         "@commercetools/sdk-client-v2": "2.5.0",
         "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.1.0",
@@ -861,15 +861,15 @@
       }
     },
     "node_modules/@commercetools/platform-sdk": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.8.0.tgz",
-      "integrity": "sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.9.0.tgz",
+      "integrity": "sha512-dj5T7DCM5YrSr5Y02OgDWHFx6GFXi/9E34TTzpJH1VjybMFLYEqD7HKHhC9a3QT0xySWGXfa+7wCnSNgq8U4Jg==",
       "dependencies": {
         "@commercetools/sdk-client-v2": "^2.5.0",
         "@commercetools/sdk-middleware-auth": "^7.0.0",
         "@commercetools/sdk-middleware-http": "^7.0.0",
         "@commercetools/sdk-middleware-logger": "^3.0.0",
-        "@commercetools/ts-client": "^1.2.1"
+        "@commercetools/ts-client": "^2.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/@commercetools/ts-client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/ts-client/-/ts-client-1.2.1.tgz",
-      "integrity": "sha512-tgy78lQoEoqYoK0KeSj43/v1Mg17M1ouwXtDxKmjAqEW4RyiCGOPPjOiZT9adTyjbK4CcOcwDzJxUVziIerg5g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/ts-client/-/ts-client-2.0.0.tgz",
+      "integrity": "sha512-yf78GbZ9SPI7DdzbLNJmiuU+NnnWfoM+NTGPVWNL77932T4oBWXPOCQenRbk4hCRvQztVh1oqfWwdRu6xyH9yg==",
       "dependencies": {
         "abort-controller": "3.0.0",
         "buffer": "^6.0.3",
@@ -9830,12 +9830,12 @@
       }
     },
     "@commercetools/connect-payments-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.7.0.tgz",
-      "integrity": "sha512-RrdJwxnDwxYyaAsuKUoAujr2ABx6ln1hiTMz0FRY9fI38aQdXTjDJkGVBQmqWJ9baxLPveRBj+GpsdtDOLcvGg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.0.tgz",
+      "integrity": "sha512-xQYDN2aQkGLn8oeTKuK/VQZfiZLer3n6lsOyl+6Cr4pTxhDH4BdciXvo1FdCZZEpisV69v6cHWC8JZ2kI4WaZw==",
       "requires": {
         "@commercetools-backend/loggers": "22.27.0",
-        "@commercetools/platform-sdk": "7.8.0",
+        "@commercetools/platform-sdk": "7.9.0",
         "@commercetools/sdk-client-v2": "2.5.0",
         "jsonwebtoken": "9.0.2",
         "jwks-rsa": "3.1.0",
@@ -9844,15 +9844,15 @@
       }
     },
     "@commercetools/platform-sdk": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.8.0.tgz",
-      "integrity": "sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-7.9.0.tgz",
+      "integrity": "sha512-dj5T7DCM5YrSr5Y02OgDWHFx6GFXi/9E34TTzpJH1VjybMFLYEqD7HKHhC9a3QT0xySWGXfa+7wCnSNgq8U4Jg==",
       "requires": {
         "@commercetools/sdk-client-v2": "^2.5.0",
         "@commercetools/sdk-middleware-auth": "^7.0.0",
         "@commercetools/sdk-middleware-http": "^7.0.0",
         "@commercetools/sdk-middleware-logger": "^3.0.0",
-        "@commercetools/ts-client": "^1.2.1"
+        "@commercetools/ts-client": "^2.0.0"
       }
     },
     "@commercetools/sdk-client-v2": {
@@ -9903,9 +9903,9 @@
       "integrity": "sha512-DhMXAA2yIch/AaGxy7st85Z1HFmeLtHWGkr9z5rX4xKjan4PHGB/IE5saAR+SNGHhs6+1Lp8vZEHDo3tFqVLmg=="
     },
     "@commercetools/ts-client": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/ts-client/-/ts-client-1.2.1.tgz",
-      "integrity": "sha512-tgy78lQoEoqYoK0KeSj43/v1Mg17M1ouwXtDxKmjAqEW4RyiCGOPPjOiZT9adTyjbK4CcOcwDzJxUVziIerg5g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/ts-client/-/ts-client-2.0.0.tgz",
+      "integrity": "sha512-yf78GbZ9SPI7DdzbLNJmiuU+NnnWfoM+NTGPVWNL77932T4oBWXPOCQenRbk4hCRvQztVh1oqfWwdRu6xyH9yg==",
       "requires": {
         "abort-controller": "3.0.0",
         "buffer": "^6.0.3",

--- a/processor/package.json
+++ b/processor/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@adyen/api-library": "17.1.0",
     "@commercetools-backend/loggers": "22.27.0",
-    "@commercetools/connect-payments-sdk": "0.7.0",
+    "@commercetools/connect-payments-sdk": "0.8.0",
     "@fastify/autoload": "5.8.3",
     "@fastify/cors": "9.0.1",
     "@fastify/formbody": "7.4.0",

--- a/processor/src/server/app.ts
+++ b/processor/src/server/app.ts
@@ -5,6 +5,7 @@ import { AdyenPaymentService } from '../services/adyen-payment.service';
 const paymentService = new AdyenPaymentService({
   ctCartService: paymentSDK.ctCartService,
   ctPaymentService: paymentSDK.ctPaymentService,
+  ctOrderService: paymentSDK.ctOrderService,
 });
 
 export const app = {

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -1,5 +1,6 @@
 import {
   CommercetoolsCartService,
+  CommercetoolsOrderService,
   CommercetoolsPaymentService,
   ErrorInvalidJsonInput,
   ErrorInvalidOperation,
@@ -25,9 +26,16 @@ import { log } from '../libs/logger';
 export abstract class AbstractPaymentService {
   protected ctCartService: CommercetoolsCartService;
   protected ctPaymentService: CommercetoolsPaymentService;
-  constructor(ctCartService: CommercetoolsCartService, ctPaymentService: CommercetoolsPaymentService) {
+  protected ctOrderService: CommercetoolsOrderService;
+
+  constructor(
+    ctCartService: CommercetoolsCartService,
+    ctPaymentService: CommercetoolsPaymentService,
+    ctOrderService: CommercetoolsOrderService,
+  ) {
     this.ctCartService = ctCartService;
     this.ctPaymentService = ctPaymentService;
+    this.ctOrderService = ctOrderService;
   }
 
   /**

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -8,7 +8,7 @@ import {
   Payment,
   UpdatePayment,
   CommercetoolsOrderService,
-  ErrorReferencedResourceNotFound,
+  Errorx,
 } from '@commercetools/connect-payments-sdk';
 import {
   ConfirmPaymentRequestDTO,
@@ -56,14 +56,7 @@ import { RefundPaymentConverter } from './converters/refund-payment.converter';
 import { log } from '../libs/logger';
 import { ApplePayPaymentSessionError, UnsupportedNotificationError } from '../errors/adyen-api.error';
 import { fetch as undiciFetch, Agent, Dispatcher } from 'undici';
-import { mapCoCoCartItemsToAdyenLineItems, mapCoCoOrderItemsToAdyenLineItems } from './converters/helper.converter';
-import { LineItem } from '@adyen/api-library/lib/src/typings/checkout/lineItem';
 const packageJSON = require('../../package.json');
-
-/**
- * These payment methods require line items to be send to Adyen.
- */
-export const METHODS_REQUIRE_LINE_ITEMS = ['klarna', 'klarna_account', 'klarna_paynow'];
 
 export type AdyenPaymentServiceOptions = {
   ctCartService: CommercetoolsCartService;
@@ -91,7 +84,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
     this.notificationConverter = new NotificationConverter();
     this.paymentComponentsConverter = new PaymentComponentsConverter();
     this.cancelPaymentConverter = new CancelPaymentConverter();
-    this.capturePaymentConverter = new CapturePaymentConverter();
+    this.capturePaymentConverter = new CapturePaymentConverter(this.ctCartService, this.ctOrderService);
     this.refundPaymentConverter = new RefundPaymentConverter();
   }
   async config(): Promise<ConfigResponse> {
@@ -405,25 +398,20 @@ export class AdyenPaymentService extends AbstractPaymentService {
   }
 
   async capturePayment(request: CapturePaymentRequest): Promise<PaymentProviderModificationResponse> {
-    // Only process if the payment method requires it so we don't fetch order/cart unnecessary.
-    let adyenLineItems: LineItem[] | undefined = undefined;
-    if (
-      request.payment.paymentMethodInfo.method &&
-      METHODS_REQUIRE_LINE_ITEMS.includes(request.payment.paymentMethodInfo.method)
-    ) {
-      adyenLineItems = await this.retrievePaymentAssociatedLineItems(request.payment.id);
-    }
-
     const interfaceId = request.payment.interfaceId as string;
     try {
       const res = await AdyenApi().ModificationsApi.captureAuthorisedPayment(
         interfaceId,
-        this.capturePaymentConverter.convertRequest(request, adyenLineItems),
+        await this.capturePaymentConverter.convertRequest(request),
       );
 
       return { outcome: PaymentModificationStatus.RECEIVED, pspReference: res.pspReference };
     } catch (e) {
-      throw wrapAdyenError(e);
+      if (e instanceof Errorx) {
+        throw e;
+      } else {
+        throw wrapAdyenError(e);
+      }
     }
   }
 
@@ -515,33 +503,6 @@ export class AdyenPaymentService extends AbstractPaymentService {
           },
         },
       );
-    }
-  }
-
-  private async retrievePaymentAssociatedLineItems(paymentId: string): Promise<LineItem[]> {
-    // First try fetching the order
-    try {
-      const order = await this.ctOrderService.getOrderByPaymentId({ paymentId });
-      return mapCoCoOrderItemsToAdyenLineItems(order);
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Could not find order for the given paymentId';
-      log.warn(msg, {
-        cause: error,
-        paymentId,
-      });
-    }
-
-    // Fallback to the cart
-    try {
-      const cart = await this.ctCartService.getCartByPaymentId({ paymentId });
-      return mapCoCoCartItemsToAdyenLineItems(cart);
-    } catch (error) {
-      throw new ErrorReferencedResourceNotFound('cart', paymentId, {
-        cause: error,
-        fields: {
-          paymentId,
-        },
-      });
     }
   }
 

--- a/processor/src/services/converters/capture-payment.converter.ts
+++ b/processor/src/services/converters/capture-payment.converter.ts
@@ -25,7 +25,7 @@ export class CapturePaymentConverter {
   }
 
   public async convertRequest(opts: CapturePaymentRequest): Promise<PaymentCaptureRequest> {
-    // Only process if the payment method requires it so we don't fetch order/cart unnecessary.
+    // Only process if the payment method requires it so we don't fetch order/cart unnecessarily.
     let adyenLineItems: LineItem[] | undefined = undefined;
     if (
       opts.payment.paymentMethodInfo.method &&

--- a/processor/src/services/converters/capture-payment.converter.ts
+++ b/processor/src/services/converters/capture-payment.converter.ts
@@ -2,9 +2,38 @@ import { config } from '../../config/config';
 import { PaymentCaptureRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentCaptureRequest';
 import { CapturePaymentRequest } from '../types/operation.type';
 import { LineItem } from '@adyen/api-library/lib/src/typings/checkout/lineItem';
+import { mapCoCoCartItemsToAdyenLineItems, mapCoCoOrderItemsToAdyenLineItems } from './helper.converter';
+import { log } from '../../libs/logger';
+import {
+  CommercetoolsCartService,
+  CommercetoolsOrderService,
+  ErrorReferencedResourceNotFound,
+} from '@commercetools/connect-payments-sdk';
+
+/**
+ * These payment methods require line items to be send to Adyen for capturing payments
+ */
+export const METHODS_REQUIRE_LINE_ITEMS = ['klarna', 'klarna_account', 'klarna_paynow'];
 
 export class CapturePaymentConverter {
-  public convertRequest(opts: CapturePaymentRequest, lineItems: LineItem[] | undefined): PaymentCaptureRequest {
+  private ctCartService: CommercetoolsCartService;
+  private ctOrderService: CommercetoolsOrderService;
+
+  constructor(ctCartService: CommercetoolsCartService, ctOrderService: CommercetoolsOrderService) {
+    this.ctCartService = ctCartService;
+    this.ctOrderService = ctOrderService;
+  }
+
+  public async convertRequest(opts: CapturePaymentRequest): Promise<PaymentCaptureRequest> {
+    // Only process if the payment method requires it so we don't fetch order/cart unnecessary.
+    let adyenLineItems: LineItem[] | undefined = undefined;
+    if (
+      opts.payment.paymentMethodInfo.method &&
+      METHODS_REQUIRE_LINE_ITEMS.includes(opts.payment.paymentMethodInfo.method)
+    ) {
+      adyenLineItems = await this.retrievePaymentAssociatedLineItems(opts.payment.id);
+    }
+
     return {
       merchantAccount: config.adyenMerchantAccount,
       reference: opts.payment.id,
@@ -12,7 +41,34 @@ export class CapturePaymentConverter {
         currency: opts.amount.currencyCode,
         value: opts.amount.centAmount,
       },
-      lineItems,
+      lineItems: adyenLineItems,
     };
+  }
+
+  private async retrievePaymentAssociatedLineItems(paymentId: string): Promise<LineItem[]> {
+    // First try fetching the order
+    try {
+      const order = await this.ctOrderService.getOrderByPaymentId({ paymentId });
+      return mapCoCoOrderItemsToAdyenLineItems(order);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Could not find order for the given paymentId';
+      log.warn(msg, {
+        cause: error,
+        paymentId,
+      });
+    }
+
+    // Fallback to the cart
+    try {
+      const cart = await this.ctCartService.getCartByPaymentId({ paymentId });
+      return mapCoCoCartItemsToAdyenLineItems(cart);
+    } catch (error) {
+      throw new ErrorReferencedResourceNotFound('cart', paymentId, {
+        cause: error,
+        fields: {
+          paymentId,
+        },
+      });
+    }
   }
 }

--- a/processor/src/services/converters/capture-payment.converter.ts
+++ b/processor/src/services/converters/capture-payment.converter.ts
@@ -1,9 +1,10 @@
 import { config } from '../../config/config';
 import { PaymentCaptureRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentCaptureRequest';
 import { CapturePaymentRequest } from '../types/operation.type';
+import { LineItem } from '@adyen/api-library/lib/src/typings/checkout/lineItem';
 
 export class CapturePaymentConverter {
-  public convertRequest(opts: CapturePaymentRequest): PaymentCaptureRequest {
+  public convertRequest(opts: CapturePaymentRequest, lineItems: LineItem[] | undefined): PaymentCaptureRequest {
     return {
       merchantAccount: config.adyenMerchantAccount,
       reference: opts.payment.id,
@@ -11,6 +12,7 @@ export class CapturePaymentConverter {
         currency: opts.amount.currencyCode,
         value: opts.amount.centAmount,
       },
+      lineItems,
     };
   }
 }

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -6,6 +6,7 @@ import {
   CustomLineItem,
   Address as CartAddress,
   ShippingInfo,
+  Order,
 } from '@commercetools/connect-payments-sdk';
 import {
   getAllowedPaymentMethodsFromContext,
@@ -62,6 +63,21 @@ export const mapCoCoDiscountOnTotalPriceToAdyenLineItem = (
     amountIncludingTax: -amountIncludingTax,
     taxAmount: -taxAmount,
   };
+};
+
+/**
+ * Maps over a CoCo order items (like lineItems, discounts, shipping, etc) over to the Adyen line items.
+ *
+ * Mapping logic is mainly based upon the Adyen `adyen-commercetools` connector.
+ *
+ * @param cart The CoCo order to map over
+ * @returns List of lineitems to be send to Adyen
+ */
+export const mapCoCoOrderItemsToAdyenLineItems = (
+  order: Pick<Order, 'lineItems' | 'customLineItems' | 'shippingInfo' | 'discountOnTotalPrice'>,
+): LineItem[] => {
+  // CoCo model between these attributes is shared between a Cart and Order hence we can re-use the existing mapping logic.
+  return mapCoCoCartItemsToAdyenLineItems(order);
 };
 
 /**

--- a/processor/test/routes.test/operations.spec.ts
+++ b/processor/test/routes.test/operations.spec.ts
@@ -4,6 +4,7 @@ import {
   AuthorityAuthorizationHook,
   AuthorityAuthorizationManager,
   CommercetoolsCartService,
+  CommercetoolsOrderService,
   CommercetoolsPaymentService,
   ContextProvider,
   JWTAuthenticationHook,
@@ -71,6 +72,7 @@ describe('/operations APIs', () => {
   const spiedPaymentService = new AdyenPaymentService({
     ctCartService: jest.fn() as unknown as CommercetoolsCartService,
     ctPaymentService: jest.fn() as unknown as CommercetoolsPaymentService,
+    ctOrderService: jest.fn() as unknown as CommercetoolsOrderService,
   });
 
   beforeAll(async () => {

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -22,11 +22,7 @@ import { mockGetCartResult } from '../utils/mock-cart-data';
 
 import * as Config from '../../src/config/config';
 import { AbstractPaymentService } from '../../src/services/abstract-payment.service';
-import {
-  AdyenPaymentService,
-  AdyenPaymentServiceOptions,
-  METHODS_REQUIRE_LINE_ITEMS,
-} from '../../src/services/adyen-payment.service';
+import { AdyenPaymentService, AdyenPaymentServiceOptions } from '../../src/services/adyen-payment.service';
 import * as StatusHandler from '@commercetools/connect-payments-sdk/dist/api/handlers/status.handler';
 import { PaymentsApi } from '@adyen/api-library/lib/src/services/checkout/paymentsApi';
 import { ModificationsApi } from '@adyen/api-library/lib/src/services/checkout/modificationsApi';
@@ -160,11 +156,6 @@ describe('adyen-payment.service', () => {
 
     const result = await paymentService.modifyPayment(modifyPaymentOpts);
     expect(result?.outcome).toStrictEqual('received');
-  });
-
-  test('METHODS_REQUIRE_LINE_ITEMS', () => {
-    const expected = ['klarna', 'klarna_account', 'klarna_paynow'];
-    expect(METHODS_REQUIRE_LINE_ITEMS).toEqual(expected);
   });
 
   describe('capturePayment', () => {

--- a/processor/test/services/converters/capture.converter.spec.ts
+++ b/processor/test/services/converters/capture.converter.spec.ts
@@ -1,0 +1,9 @@
+import { describe, test, expect } from '@jest/globals';
+import { METHODS_REQUIRE_LINE_ITEMS } from '../../../src/services/converters/capture-payment.converter';
+
+describe('capture.converter', () => {
+  test('METHODS_REQUIRE_LINE_ITEMS', () => {
+    const expected = ['klarna', 'klarna_account', 'klarna_paynow'];
+    expect(METHODS_REQUIRE_LINE_ITEMS).toEqual(expected);
+  });
+});

--- a/processor/test/utils/mock-order-data.ts
+++ b/processor/test/utils/mock-order-data.ts
@@ -1,0 +1,203 @@
+import { Order } from '@commercetools/connect-payments-sdk';
+
+export const mockGetOrderResult: Order = {
+  id: '123456',
+  version: 1,
+  createdAt: '2024-02-13T00:00:00.000Z',
+  lastModifiedAt: '2024-02-13T00:00:00.000Z',
+  customLineItems: [],
+  lineItems: [
+    {
+      id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+      productId: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+      productKey: 'walnut-counter-stool',
+      name: {
+        'en-US': 'Walnut Counter Stool',
+        'en-GB': 'Walnut Counter Stool',
+        'de-DE': 'Barhocker aus Nussbaumholz',
+      },
+      productType: {
+        typeId: 'product-type',
+        id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+      },
+      productSlug: {
+        'en-US': 'walnut-counter-stool',
+        'en-GB': 'walnut-counter-stool',
+        'de-DE': 'barhocker-aus-walnussholz',
+      },
+      variant: {
+        id: 1,
+        sku: 'WCSI-09',
+        prices: [
+          {
+            id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+            value: {
+              type: 'centPrecision',
+              currencyCode: 'EUR',
+              centAmount: 8999,
+              fractionDigits: 2,
+            },
+          },
+          {
+            id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+            value: {
+              type: 'centPrecision',
+              currencyCode: 'GBP',
+              centAmount: 8999,
+              fractionDigits: 2,
+            },
+            country: 'GB',
+          },
+          {
+            id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+            value: {
+              type: 'centPrecision',
+              currencyCode: 'USD',
+              centAmount: 8999,
+              fractionDigits: 2,
+            },
+            country: 'US',
+          },
+        ],
+        images: [
+          {
+            url: 'https://imagedomain.com/Walnut_Counter_Stool-1.1.jpeg',
+            dimensions: {
+              w: 5906,
+              h: 5906,
+            },
+          },
+        ],
+        attributes: [
+          {
+            name: 'productspec',
+            value: {
+              'en-GB': '- Includes 1 stool',
+              'en-US': '- Includes 1 stool',
+              'de-DE': '- Beinhaltet 1 Hocker',
+            },
+          },
+          {
+            name: 'color-filter',
+            value: {
+              key: '#964B00',
+              label: {
+                'de-DE': 'Dunkelbraun',
+                'en-GB': 'Dark Brown',
+                'en-US': 'Dark Brown',
+              },
+            },
+          },
+          {
+            name: 'finishlabel',
+            value: {
+              'en-GB': 'Walnut',
+              'de-DE': 'Nussbaum',
+              'en-US': 'Walnut',
+            },
+          },
+          {
+            name: 'finish',
+            value: {
+              'en-GB': '#75412E',
+              'en-US': '#75412E',
+              'de-DE': '#75412E',
+            },
+          },
+        ],
+        assets: [],
+        availability: {
+          isOnStock: true,
+          availableQuantity: 100,
+          version: 1,
+          id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+        },
+      },
+      price: {
+        id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+        value: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 8999,
+          fractionDigits: 2,
+        },
+      },
+      quantity: 1,
+      discountedPricePerQuantity: [],
+      taxRate: {
+        name: 'Standard VAT for NL',
+        amount: 0.19,
+        includedInPrice: true,
+        country: 'NL',
+        id: 'vDls7YG4',
+        key: 'vat-standard-nl',
+        subRates: [],
+      },
+      perMethodTaxRate: [],
+      addedAt: '2024-06-06T09:06:09.197Z',
+      lastModifiedAt: '2024-06-06T09:06:09.197Z',
+      state: [
+        {
+          quantity: 1,
+          state: {
+            typeId: 'state',
+            id: 'fbb6ea54-e96b-4ebe-b4c9-ccad345bd5d6',
+          },
+        },
+      ],
+      priceMode: 'Platform',
+      lineItemMode: 'Standard',
+      totalPrice: {
+        type: 'centPrecision',
+        currencyCode: 'EUR',
+        centAmount: 8999,
+        fractionDigits: 2,
+      },
+      taxedPrice: {
+        totalNet: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 7562,
+          fractionDigits: 2,
+        },
+        totalGross: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 8999,
+          fractionDigits: 2,
+        },
+        taxPortions: [
+          {
+            rate: 0.19,
+            amount: {
+              type: 'centPrecision',
+              currencyCode: 'EUR',
+              centAmount: 1437,
+              fractionDigits: 2,
+            },
+            name: 'Standard VAT for NL',
+          },
+        ],
+        totalTax: {
+          type: 'centPrecision',
+          currencyCode: 'EUR',
+          centAmount: 1437,
+          fractionDigits: 2,
+        },
+      },
+      taxedPricePortions: [],
+    },
+  ],
+  orderState: '',
+  origin: '',
+  refusedGifts: [],
+  shipping: [],
+  shippingMode: '',
+  syncInfo: [],
+  totalPrice: {
+    centAmount: 8999,
+    currencyCode: 'EUR',
+    type: 'centPrecision',
+    fractionDigits: 2,
+  },
+};

--- a/processor/test/utils/mock-payment-data.ts
+++ b/processor/test/utils/mock-payment-data.ts
@@ -29,6 +29,27 @@ export const mockGetPaymentResult: Payment = {
   lastModifiedAt: '2024-02-13T00:00:00.000Z',
 };
 
+export const mockGetPaymentResultKlarnaPayLater: Payment = {
+  id: '123456',
+  version: 1,
+  amountPlanned: {
+    type: 'centPrecision',
+    currencyCode: 'GBP',
+    centAmount: 120000,
+    fractionDigits: 2,
+  },
+  interfaceId: '92C12661DS923781G',
+  paymentMethodInfo: {
+    method: 'klarna',
+    name: { 'en-US': 'Klarna Pay later', 'en-GB': 'Klarna Pay later' },
+  },
+  paymentStatus: { interfaceText: 'Paid' },
+  transactions: [],
+  interfaceInteractions: [],
+  createdAt: '2024-02-13T00:00:00.000Z',
+  lastModifiedAt: '2024-02-13T00:00:00.000Z',
+};
+
 const mockCancelPaymentTransaction: Transaction = {
   id: 'dummy-transaction-id',
   timestamp: '2024-02-13T00:00:00.000Z',
@@ -55,6 +76,27 @@ export const mockUpdatePaymentResult: Payment = {
   paymentMethodInfo: {
     method: 'Debit Card',
     name: { 'en-US': 'Debit Card', 'en-GB': 'Debit Card' },
+  },
+  paymentStatus: { interfaceText: 'Paid' },
+  transactions: [mockCancelPaymentTransaction],
+  interfaceInteractions: [],
+  createdAt: '2024-02-13T00:00:00.000Z',
+  lastModifiedAt: '2024-02-13T00:00:00.000Z',
+};
+
+export const mockUpdatePaymentResultKlarnaPayLater: Payment = {
+  id: '123456',
+  version: 1,
+  amountPlanned: {
+    type: 'centPrecision',
+    currencyCode: 'GBP',
+    centAmount: 120000,
+    fractionDigits: 2,
+  },
+  interfaceId: '92C12661DS923781G',
+  paymentMethodInfo: {
+    method: 'klarna',
+    name: { 'en-US': 'Klarna Pay later', 'en-GB': 'Klarna Pay later' },
   },
   paymentStatus: { interfaceText: 'Paid' },
   transactions: [mockCancelPaymentTransaction],


### PR DESCRIPTION
**Ticket [SCC-2373](https://commercetools.atlassian.net/browse/SCC-2373)**

**Description**

For certain payment methods, in this case for `klarna` (Pay Later), `klarna_account` (Pay Over Time) and `klarna_paynow` (Pay Now) it requires us to send the line items to Adyen again during a `capture` API call. Same as during the authorisation call. In this PR we extend the `capture` API code to include this.

Sending lineitems to Adyen is conditional. Only if the payment method is (at the time of this PR) one of the three klarna payment methods will we trigger this new logic.

When a payment capture request is coming in we only know the `paymentID` so via this ID we will fetch the CoCo order and as a fallback the cart. If neither could be found an error is returned to the API caller without the capture request to Adyen happening.

**Technical notes**

In order to be able to fetch the order/cart this PR builds upon the change from https://github.com/commercetools/connect-payments-sdk/pull/93 and the new released version of `0.8.0` from the `connect-payments-sdk` package.