### PR TITLE
feat(payments): added support for payment methods that do not accept separate captures

### DIFF
--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -1,0 +1,19 @@
+/**
+ * Specific configuration for payment methods that require special handling.
+ * See https://docs.adyen.com/payment-methods for more information about each payment method.
+ */
+
+export type PaymentMethodConfig = {
+  [key: string]: {
+    /**
+     * Whether the payment method supports separate capture.
+     */
+    supportSeparateCapture: boolean;
+  };
+};
+
+export const paymentMethodConfig: PaymentMethodConfig = {
+  ideal: {
+    supportSeparateCapture: false,
+  },
+};

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -2,7 +2,7 @@ import { PaymentRequest } from '@adyen/api-library/lib/src/typings/checkout/paym
 import { config } from '../../config/config';
 import { ThreeDSRequestData } from '@adyen/api-library/lib/src/typings/checkout/threeDSRequestData';
 import { Cart, Payment } from '@commercetools/connect-payments-sdk';
-import { buildReturnUrl, populateCartAddress, mapCoCoCartItemsToAdyenLineItems } from './helper.converter';
+import { buildReturnUrl, populateCartAddress } from './helper.converter';
 import { CreatePaymentRequestDTO } from '../../dtos/adyen-payment.dto';
 
 export class CreatePaymentConverter {

--- a/processor/src/services/types/service.type.ts
+++ b/processor/src/services/types/service.type.ts
@@ -1,0 +1,7 @@
+import { TransactionData } from '@commercetools/connect-payments-sdk';
+export type NotificationUpdatePayment = {
+  id: string;
+  pspReference?: string;
+  transactions: TransactionData[];
+  paymentMethod?: string;
+};

--- a/processor/test/services/converters/notification.converter.spec.ts
+++ b/processor/test/services/converters/notification.converter.spec.ts
@@ -1,0 +1,686 @@
+import { describe, test, expect } from '@jest/globals';
+import { NotificationConverter } from '../../../src/services/converters/notification.converter';
+import { NotificationRequestDTO } from '../../../src/dtos/adyen-payment.dto';
+import { NotificationRequestItem } from '@adyen/api-library/lib/src/typings/notification/notificationRequestItem';
+import { UnsupportedNotificationError } from '../../../src/errors/adyen-api.error';
+
+describe('notification.converter', () => {
+  const converter = new NotificationConverter();
+
+  test('convert a successful card payment notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Authorization',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a successful ideal payment notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'ideal';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {},
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Authorization',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+        {
+          type: 'Charge',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a failure ideal payment notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'ideal';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {},
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Authorization',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a expired payment notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Expire,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Authorization',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a successful card capture notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Capture,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Charge',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a failed card capture notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.CaptureFailed,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Charge',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a successful card cancellation notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Cancellation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'CancelAuthorization',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a failed card cancellation notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Cancellation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'CancelAuthorization',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a successful card refund notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Refund,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Refund',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a failed card refund notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Refund,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Refund',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a refund failed notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.RefundFailed,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Refund',
+          state: 'Failure',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a chargeback notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Chargeback,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = converter.convert({ data: notification });
+
+    // Assert
+    expect(result).toEqual({
+      id: merchantReference,
+      pspReference,
+      paymentMethod,
+      transactions: [
+        {
+          type: 'Chargeback',
+          state: 'Success',
+          amount: {
+            currencyCode: 'EUR',
+            centAmount: 10000,
+          },
+          interactionId: pspReference,
+        },
+      ],
+    });
+  });
+
+  test('convert a non supported event notification', () => {
+    // Arrange
+    const merchantReference = 'some-merchant-reference';
+    const pspReference = 'some-psp-reference';
+    const paymentMethod = 'visa';
+    const notification: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              expiryDate: '12/2012',
+              authCode: '1234',
+              cardSummary: '7777',
+            },
+            amount: {
+              currency: 'EUR',
+              value: 10000,
+            },
+            eventCode: NotificationRequestItem.EventCodeEnum.Donation,
+            eventDate: '2024-06-17T11:37:05+02:00',
+            merchantAccountCode: 'MyMerchantAccount',
+            merchantReference,
+            paymentMethod,
+            pspReference,
+            success: NotificationRequestItem.SuccessEnum.False,
+          },
+        },
+      ],
+    };
+
+    // Act
+    try {
+      converter.convert({ data: notification });
+    } catch (error) {
+      // Assert
+      expect(error).toBeInstanceOf(UnsupportedNotificationError);
+    }
+  });
+});


### PR DESCRIPTION
Added support for payment methods that do not accept separate captures. 
Those payment methods are auto captured so we are creating the Charge transaction for those cases when Adyen confirms the payment so that we can keep synced the CoCo payment state and the Adyen payment

More details on ticket: https://commercetools.atlassian.net/browse/SCC-2400 