### PR TITLE
feat(payment): add `EPS` payment method support

### DIFF
--- a/enabler/dev-utils/session.js
+++ b/enabler/dev-utils/session.js
@@ -52,6 +52,7 @@ const getSessionId = async (cartId) => {
       "paypal",
       "applepay",
       "googlepay",
+      "eps"
     ], // add here your allowed methods for development purposes
   };
 

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -169,7 +169,7 @@
                 });
 
                 if (builder.componentHasSubmit) {
-                  const methodsRequireMounting = ['eps', 'card', 'klarna', 'klarna_paynow', 'klarna_account'];
+                  const methodsRequireMounting = ['eps', 'card', 'klarna_pay_now', 'klarna_pay_later', 'klarna_pay_overtime'];
                   if (methodsRequireMounting.includes(selectedValue)) {
                     component.mount("#container--external");
                   }

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -169,7 +169,8 @@
                 });
 
                 if (builder.componentHasSubmit) {
-                  if (selectedValue === 'card') {
+                  const methodsRequireMounting = ['eps', 'card', 'klarna', 'klarna_paynow', 'klarna_account'];
+                  if (methodsRequireMounting.includes(selectedValue)) {
                     component.mount("#container--external");
                   }
                   

--- a/enabler/src/components/payment-methods/eps.ts
+++ b/enabler/src/components/payment-methods/eps.ts
@@ -1,0 +1,52 @@
+import Core from "@adyen/adyen-web/dist/types/core/core";
+import {
+  ComponentOptions,
+  PaymentComponent,
+  PaymentMethod
+} from "../../payment-enabler/payment-enabler";
+import {
+  AdyenBaseComponentBuilder,
+  DefaultAdyenComponent,
+  BaseOptions,
+} from "../base";
+
+/**
+ * EPS component
+ *
+ * Configuration options:
+ * https://docs.adyen.com/payment-methods/eps/web-component/
+ */
+export class EPSBuilder extends AdyenBaseComponentBuilder {
+
+  constructor(baseOptions: BaseOptions) {
+    super(PaymentMethod.eps, baseOptions);
+  }
+
+  build(config: ComponentOptions): PaymentComponent {
+    const epsComponent = new EPSComponent({
+      paymentMethod: this.paymentMethod,
+      adyenCheckout: this.adyenCheckout,
+      componentOptions: config,
+      sessionId: this.sessionId,
+      processorUrl: this.processorUrl,
+    });
+    epsComponent.init();
+    return epsComponent;
+  }
+}
+
+export class EPSComponent extends DefaultAdyenComponent {
+  constructor(opts: {
+    paymentMethod: PaymentMethod;
+    adyenCheckout: typeof Core;
+    componentOptions: ComponentOptions;
+    sessionId: string;
+    processorUrl: string;
+  }) {
+    super(opts);
+  }
+
+  init() {
+    this.component = this.adyenCheckout.create(this.paymentMethod, {});
+  }
+}

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -14,6 +14,7 @@ import { PaypalBuilder } from "../components/payment-methods/paypal";
 import { KlarnaPayNowBuilder } from "../components/payment-methods/klarna-pay-now";
 import { KlarnaPayLaterBuilder } from "../components/payment-methods/klarna-pay-later";
 import { KlarnaPayOverTimeBuilder } from "../components/payment-methods/klarna-pay-over-time";
+import { EPSBuilder } from "../components/payment-methods/eps";
 
 class AdyenInitError extends Error {
   sessionId: string;
@@ -187,6 +188,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
       klarna_pay_now: KlarnaPayNowBuilder,
       klarna_pay_later: KlarnaPayLaterBuilder,
       klarna_pay_overtime: KlarnaPayOverTimeBuilder,
+      eps: EPSBuilder
     };
     if (!Object.keys(supportedMethods).includes(type)) {
       throw new Error(

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -37,6 +37,7 @@ export enum PaymentMethod {
   klarna_pay_now = "klarna_paynow", // Pay now
   klarna_pay_later = "klarna", // Pay later
   klarna_pay_overtime = "klarna_account", // Pay over time
+  eps = "eps"
 }
 
 export type PaymentResult = {

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -16,4 +16,7 @@ export const paymentMethodConfig: PaymentMethodConfig = {
   ideal: {
     supportSeparateCapture: false,
   },
+  eps: {
+    supportSeparateCapture: false,
+  },
 };

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -517,7 +517,11 @@ export class AdyenPaymentService extends AbstractPaymentService {
   private convertAdyenResultCode(resultCode: PaymentResponse.ResultCodeEnum, isActionRequired: boolean): string {
     if (resultCode === PaymentResponse.ResultCodeEnum.Authorised) {
       return 'Success';
-    } else if (resultCode === PaymentResponse.ResultCodeEnum.Pending && !isActionRequired) {
+    } else if (
+      (resultCode === PaymentResponse.ResultCodeEnum.Pending ||
+        resultCode === PaymentResponse.ResultCodeEnum.Received) &&
+      !isActionRequired
+    ) {
       return 'Pending';
     } else if (
       resultCode === PaymentResponse.ResultCodeEnum.Refused ||

--- a/processor/src/services/converters/payment-components.converter.ts
+++ b/processor/src/services/converters/payment-components.converter.ts
@@ -28,6 +28,9 @@ export class PaymentComponentsConverter {
         {
           type: 'klarna_pay_overtime', // klarna_account
         },
+        {
+          type: 'eps',
+        },
       ],
     };
   }

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -412,6 +412,7 @@ describe('adyen-payment.service', () => {
     jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
     jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
     jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
+    jest.spyOn(FastifyContext, 'getMerchantReturnUrlFromContext').mockReturnValue('http://127.0.0.1/checkout/result');
     jest.spyOn(PaymentsApi.prototype, 'payments').mockResolvedValue(mockAdyenCreatePaymentResponse);
 
     jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockGetPaymentResult);
@@ -438,6 +439,7 @@ describe('adyen-payment.service', () => {
     jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
     jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
     jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
+    jest.spyOn(FastifyContext, 'getMerchantReturnUrlFromContext').mockReturnValue('http://127.0.0.1/checkout/result');
     jest.spyOn(PaymentsApi.prototype, 'payments').mockResolvedValue(mockAdyenCreatePaymentResponse);
 
     jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockGetPaymentResult);
@@ -464,6 +466,7 @@ describe('adyen-payment.service', () => {
     jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
     jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResult());
     jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
+    jest.spyOn(FastifyContext, 'getMerchantReturnUrlFromContext').mockReturnValue('http://127.0.0.1/checkout/result');
     jest.spyOn(PaymentsApi.prototype, 'payments').mockResolvedValue(mockAdyenCreatePaymentResponse);
 
     jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockGetPaymentResult);

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -98,7 +98,7 @@ describe('adyen-payment.service', () => {
 
   test('getSupportedPaymentComponents', async () => {
     const result: SupportedPaymentComponentsSchemaDTO = await paymentService.getSupportedPaymentComponents();
-    expect(result?.components).toHaveLength(8);
+    expect(result?.components).toHaveLength(9);
     expect(result?.components[0]?.type).toStrictEqual('card');
     expect(result?.components[1]?.type).toStrictEqual('ideal');
     expect(result?.components[2]?.type).toStrictEqual('paypal');
@@ -107,6 +107,7 @@ describe('adyen-payment.service', () => {
     expect(result?.components[5]?.type).toStrictEqual('klarna_pay_now');
     expect(result?.components[6]?.type).toStrictEqual('klarna_pay_later');
     expect(result?.components[7]?.type).toStrictEqual('klarna_pay_overtime');
+    expect(result?.components[8]?.type).toStrictEqual('eps');
   });
 
   test('getStatus', async () => {


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2403

This PR adds support for the Austrian payment methods `EPS` via Adyen. See the screenshots below of how it looks on the Adyen test environment simulator pages.

-----

![image](https://github.com/commercetools/connect-payment-integration-adyen/assets/107549011/a1a3a131-5eaa-4ebd-a45a-d4879a63b268)

![image](https://github.com/commercetools/connect-payment-integration-adyen/assets/107549011/65f82a1f-ee80-4625-aa71-7970ab96d6a3)

![image](https://github.com/commercetools/connect-payment-integration-adyen/assets/107549011/ed1d826a-1c61-48d7-97a5-9872f70caa13)

![image](https://github.com/commercetools/connect-payment-integration-adyen/assets/107549011/3e037ead-6cb4-4ccf-aa0a-b06f0093df25)
