### PR TITLE
Easing up Adyen setup

### DIFF
--- a/connect.yaml
+++ b/connect.yaml
@@ -3,7 +3,7 @@ deployAs:
     applicationType: assets
   - name: processor
     applicationType: service
-    endpoint: /
+    endpoint: /notifications
     configuration:
       standardConfiguration:
         - key: CTP_PROJECT_KEY


### PR DESCRIPTION
"/notifications" endpoint is missing in URL for url for users to copy paste and configure webhook in adyen.