### PR TITLE
fix(processor): the health check status endpoint now returns the message attribute

### DIFF
--- a/processor/src/dtos/operations/status.dto.ts
+++ b/processor/src/dtos/operations/status.dto.ts
@@ -10,6 +10,7 @@ export const StatusResponseSchema = Type.Object({
       name: Type.String(),
       status: Type.String(),
       details: Type.Optional(Type.Any()),
+      message: Type.Optional(Type.String()),
     }),
   ),
 });

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -127,9 +127,11 @@ export class AdyenPaymentService extends AbstractPaymentService {
               },
             };
           } catch (e) {
+            const errorMessage = e instanceof Error ? e.message : 'Failed to connect with Adyen';
             return {
               name: 'Adyen Status check',
               status: 'DOWN',
+              message: errorMessage,
               details: {
                 error: e,
               },
@@ -155,6 +157,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
             name: 'Adyen Apple Pay config check',
             status,
             ...(status === 'DOWN' && {
+              message:
+                'Apple Pay configuration is not complete, please fill in all the Apple Pay "own" environment variables',
               details: {
                 error:
                   'Apple Pay configuration is not complete, please fill in all the Apple Pay "own" environment variables',

--- a/processor/test/routes.test/operations.spec.ts
+++ b/processor/test/routes.test/operations.spec.ts
@@ -235,7 +235,6 @@ describe('/operations APIs', () => {
       });
 
       //Then
-      console.log(JSON.stringify(await responseGetStatus.json()));
       expect(responseGetStatus.statusCode).toEqual(200);
       expect(responseGetStatus.json()).toEqual(
         expect.objectContaining({

--- a/processor/test/routes.test/operations.spec.ts
+++ b/processor/test/routes.test/operations.spec.ts
@@ -197,11 +197,14 @@ describe('/operations APIs', () => {
         checks: [
           {
             name: 'Adyen Status check',
-            status: 'UP',
+            status: 'DOWN',
+            message: 'Failed to connect with Adyen',
           },
           {
             name: 'Adyen Apple Pay config check',
-            status: 'UP',
+            status: 'DOWN',
+            message:
+              'Apple Pay configuration is not complete, please fill in all the Apple Pay "own" environment variables',
           },
           {
             name: 'CoCo Permissions',
@@ -263,11 +266,14 @@ describe('/operations APIs', () => {
             }),
             expect.objectContaining({
               name: 'Adyen Status check',
-              status: 'UP',
+              status: 'DOWN',
+              message: 'Failed to connect with Adyen',
             }),
             expect.objectContaining({
               name: 'Adyen Apple Pay config check',
-              status: 'UP',
+              status: 'DOWN',
+              message:
+                'Apple Pay configuration is not complete, please fill in all the Apple Pay "own" environment variables',
             }),
           ]),
         }),

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -115,6 +115,7 @@ describe('adyen-payment.service', () => {
         name: 'CoCo Permissions',
         status: 'DOWN',
         details: {},
+        message: 'Invalid permissions',
       };
       return result;
     };
@@ -129,6 +130,7 @@ describe('adyen-payment.service', () => {
     expect(result?.checks[0]?.name).toStrictEqual('CoCo Permissions');
     expect(result?.checks[0]?.status).toStrictEqual('DOWN');
     expect(result?.checks[0]?.details).toStrictEqual({});
+    expect(result?.checks[0]?.message).toStrictEqual('Invalid permissions');
     expect(result?.checks[1]?.name).toStrictEqual('Adyen Status check');
     expect(result?.checks[1]?.status).toStrictEqual('UP');
     expect(result?.checks[1]?.details).toBeDefined();


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2459

I was making a PR fix to allow the commercetools Checkout mc-app to show the first `message` of any health check with the status `DOWN` however I never saw it returned from the Adyen connector.

After some digging I found out that the the status handler of the [connect-payments-sdk](https://github.com/commercetools/connect-payments-sdk/blob/main/src/api/handlers/status.handler.ts#L34) returns a optional `message` attribute on the root level of any `check` object.

However the Adyen connector health check API definition has it's own DTO model. That DTO model did not have the `message` property defined causing it to be stripped out even if it was defined in the handler itself. This PR fixes it. I have added unit-test to validate that it works as expected.

----
This is the response that it currently returns. Note there is no `message` attribute in the `CoCo Permissions` check on the root level. Even though that check in the [status handler](https://github.com/commercetools/connect-payments-sdk/blob/main/src/api/handlers/status.handler.ts#L132) of the connect-payments-sdk always sets a message there.

```json
{
    "status": "Partially Available",
    "timestamp": "2024-01-01T00:00:00Z",
    "version": "1.0.0",
    "checks": [
        {
            "name": "Adyen Status check",
            "status": "UP"
        },
        {
            "name": "Adyen Apple Pay config check",
            "status": "UP"
        },
        {
            "name": "CoCo Permissions",
            "status": "DOWN",
            "details": {
                "expectedScopes": [
                    "manage_payments",
                    "view_sessions",
                    "view_api_clients",
                    "manage_orders",
                    "introspect_oauth_tokens",
                    "manage_checkout_payment_intents"
                ],
                "actualScopes": "manage_payments:dev-commercetools-checkout view_api_clients:dev-commercetools-checkout manage_orders:dev-commercetools-checkout introspect_oauth_tokens:dev-commercetools-checkout manage_checkout_payment_intents:dev-commercetools-checkout view_payments:dev-commercetools-checkout view_orders:dev-commercetools-checkout",
                "reason": "scopes not available"
            }
        }
    ],
    "metadata": {
        "name": "payment-integration-adyen",
        "description": "Payment integration with Adyen"
    }
}
```

This is the response after the DTO change. Notice the `message` attribute is now returned from the API response.
```json
{
    "status": "Partially Available",
    "timestamp": "2024-01-01T00:00:00Z",
    "version": "1.0.0",
    "checks": [
        {
            "name": "Adyen Status check",
            "status": "UP"
        },
        {
            "name": "Adyen Apple Pay config check",
            "status": "UP"
        },
        {
            "name": "CoCo Permissions",
            "status": "DOWN",
            "details": {
                "expectedScopes": [
                    "manage_payments",
                    "view_sessions",
                    "view_api_clients",
                    "manage_orders",
                    "introspect_oauth_tokens",
                    "manage_checkout_payment_intents"
                ],
                "actualScopes": "manage_payments:dev-commercetools-checkout view_api_clients:dev-commercetools-checkout manage_orders:dev-commercetools-checkout introspect_oauth_tokens:dev-commercetools-checkout manage_checkout_payment_intents:dev-commercetools-checkout view_payments:dev-commercetools-checkout view_orders:dev-commercetools-checkout",
                "reason": "scopes not available"
            },
            "message": "CoCo permissions are not correct, expected scopes: manage_payments view_sessions view_api_clients manage_orders introspect_oauth_tokens manage_checkout_payment_intents, actual scopes: manage_payments:dev-commercetools-checkout view_api_clients:dev-commercetools-checkout manage_orders:dev-commercetools-checkout introspect_oauth_tokens:dev-commercetools-checkout manage_checkout_payment_intents:dev-commercetools-checkout view_payments:dev-commercetools-checkout view_orders:dev-commercetools-checkout"
        }
    ],
    "metadata": {
        "name": "payment-integration-adyen",
        "description": "Payment integration with Adyen"
    }
}
```