### PR TITLE
chore(processor): improve error message of status handlers

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@adyen/api-library": "17.3.0",
         "@commercetools-backend/loggers": "22.29.0",
-        "@commercetools/connect-payments-sdk": "0.8.1",
+        "@commercetools/connect-payments-sdk": "0.8.2",
         "@fastify/autoload": "5.10.0",
         "@fastify/cors": "9.0.1",
         "@fastify/formbody": "7.4.0",
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@commercetools/connect-payments-sdk": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.1.tgz",
-      "integrity": "sha512-XfX1l+wRgIy4KUGqowfMP9IioOKXLx+TQq2/7OXu5KpC29vuTinbjkQgE7rZzyTBR+lYBiz2RkLay3r9XFwQow==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.2.tgz",
+      "integrity": "sha512-q2nihmFgqqv/I/HKbKz1KFAdJxjs6e1XGxIJxvOV06WxXo7IRgabg94k4CDw+sMf0sQfJu8/VobraOYdka+THw==",
       "dependencies": {
         "@commercetools-backend/loggers": "22.29.0",
         "@commercetools/platform-sdk": "7.9.0",
@@ -9764,9 +9764,9 @@
       }
     },
     "@commercetools/connect-payments-sdk": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.1.tgz",
-      "integrity": "sha512-XfX1l+wRgIy4KUGqowfMP9IioOKXLx+TQq2/7OXu5KpC29vuTinbjkQgE7rZzyTBR+lYBiz2RkLay3r9XFwQow==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.8.2.tgz",
+      "integrity": "sha512-q2nihmFgqqv/I/HKbKz1KFAdJxjs6e1XGxIJxvOV06WxXo7IRgabg94k4CDw+sMf0sQfJu8/VobraOYdka+THw==",
       "requires": {
         "@commercetools-backend/loggers": "22.29.0",
         "@commercetools/platform-sdk": "7.9.0",

--- a/processor/package.json
+++ b/processor/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@adyen/api-library": "17.3.0",
     "@commercetools-backend/loggers": "22.29.0",
-    "@commercetools/connect-payments-sdk": "0.8.1",
+    "@commercetools/connect-payments-sdk": "0.8.2",
     "@fastify/autoload": "5.10.0",
     "@fastify/cors": "9.0.1",
     "@fastify/formbody": "7.4.0",

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -127,11 +127,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
               },
             };
           } catch (e) {
-            const errorMessage = e instanceof Error ? e.message : 'Failed to connect with Adyen';
             return {
               name: 'Adyen Status check',
               status: 'DOWN',
-              message: errorMessage,
+              message: `Not able to talk to the Adyen API`,
               details: {
                 error: e,
               },


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2459

- Bump the `@commercetools/connect-payments-sdk` to `0.8.2` so that it includes https://github.com/commercetools/connect-payments-sdk/pull/109
- Change the Adyen health check error message to include a improved message which is inline with the above changes for the commercetools permissions health check