### PR TITLE
feat(payments): manage pending responses

### DIFF
--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -108,7 +108,10 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
                 });
               component.handleAction(data.action);
             } else {
-              if (data.resultCode === "Authorised") {
+              if (
+                data.resultCode === "Authorised" ||
+                data.resultCode === "Pending"
+              ) {
                 component.setStatus("success");
                 options.onComplete &&
                   options.onComplete({ isSuccess: true, paymentReference });
@@ -140,7 +143,10 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
             body: JSON.stringify(requestData),
           });
           const data = await response.json();
-          if (data.resultCode === "Authorised") {
+          if (
+            data.resultCode === "Authorised" ||
+            data.resultCode === "Pending"
+          ) {
             component.setStatus("success");
             options.onComplete &&
               options.onComplete({ isSuccess: true, paymentReference });


### PR DESCRIPTION
Managed pending responses in the Adyen payment enabler to handle the "Pending" resultCode in addition to the "Authorised" resultCode. We take this status optimistically as a success and set the status to "success" in the component as we do the same in the BE.
