### PR TITLE
fix(paypal): fixed paypal button width for drop-in

### DIFF
--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -113,6 +113,9 @@ export class DropinComponents implements DropinComponent {
           blockPayPalCreditButton: true,
           blockPayPalPayLaterButton: true,
           blockPayPalVenmoButton: true,
+          style: {
+            disableMaxWidth: true,
+          },
           onClick: () => {
             if (this.dropinOptions.onPayButtonClick) {
               return this.dropinOptions


### PR DESCRIPTION
fixed PayPal button width to fit in the container.
Before
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/05de9869-4721-46bc-a539-0b563f8df188">

After
<img width="1183" alt="image" src="https://github.com/user-attachments/assets/297640ae-534f-4a4b-b797-65ed63e1803d">
