### PR TITLE
feat(notifications): accept payment not found notifications 

### DIFF
--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -400,7 +400,11 @@ export class AdyenPaymentService extends AbstractPaymentService {
       if (e instanceof UnsupportedNotificationError) {
         log.info('Unsupported notification received', { notification: JSON.stringify(opts.data) });
         return;
+      } else if (e instanceof Errorx && e.httpErrorStatus === 404) {
+        log.info('Payment not found hence accepting the notification', { notification: JSON.stringify(opts.data) });
+        return;
       }
+
       log.error('Error processing notification', { error: e });
       throw e;
     }


### PR DESCRIPTION
In order to solve: https://commercetools.atlassian.net/browse/CHECKOUT-171 
Accept the notifications which throw errors because the payment can't be found. As this is not a recoverable case, we just accept it so Adyen won't retry the same notification.

When a notification can't be or should not be processed, that's the pattern to follow.

