### PR TITLE
fix(processor): make sure typebox has the `0.33.x` semvar so that it remains compatible with fastify typebox plugin

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -19,7 +19,7 @@
         "@fastify/request-context": "6.0.1",
         "@fastify/static": "8.0.2",
         "@fastify/type-provider-typebox": "5.0.1",
-        "@sinclair/typebox": "0.33.22",
+        "@sinclair/typebox": "~0.33",
         "dotenv": "16.4.5",
         "fastify": "5.1.0",
         "fastify-plugin": "5.0.1"

--- a/processor/package.json
+++ b/processor/package.json
@@ -31,7 +31,7 @@
     "@fastify/request-context": "6.0.1",
     "@fastify/static": "8.0.2",
     "@fastify/type-provider-typebox": "5.0.1",
-    "@sinclair/typebox": "0.33.22",
+    "@sinclair/typebox": "~0.33",
     "dotenv": "16.4.5",
     "fastify": "5.1.0",
     "fastify-plugin": "5.0.1"


### PR DESCRIPTION
The https://github.com/commercetools/connect-payment-integration-adyen/pull/261 is failing cause of the following issue. Is the same for all connectors. I will update those if we approve of this PR.

In dependabot the `@sinclair/typebox` is trying to get bumped to `0.34.3` however the `@fastify/type-provider-typebox` package has a [peerDependency](https://github.com/fastify/fastify-type-provider-typebox/blob/main/package.json#L21) for `@sinclair/typebox` specified as `>=0.26 <=0.33`. 

So as long as the fastify typebox plugin does not get updated we won't be able to install a new version of `@sinclair/typebox`. This PR updates the `package.json` so that we will only allow `0.33.x` versions thus satisfying the peerDependency. The dependabot PR should work again after rebasing once this merged.

This is the error message from `npm`:

```cli
npm ERR! While resolving: @fastify/type-provider-typebox@5.0.1
npm ERR! Found: @sinclair/typebox@0.34.3
npm ERR! node_modules/@sinclair/typebox
npm ERR!   @sinclair/typebox@"0.34.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @sinclair/typebox@">=0.26 <=0.33" from @fastify/type-provider-typebox@5.0.1
npm ERR! node_modules/@fastify/type-provider-typebox
npm ERR!   @fastify/type-provider-typebox@"5.0.1" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @sinclair/typebox@0.33.22
npm ERR! node_modules/@sinclair/typebox
npm ERR!   peer @sinclair/typebox@">=0.26 <=0.33" from @fastify/type-provider-typebox@5.0.1
npm ERR!   node_modules/@fastify/type-provider-typebox
npm ERR!     @fastify/type-provider-typebox@"5.0.1" from the root project
```

This change will at the long term introduce a tiny bit of maintenance since we will never go above `0.33.x`. So if fastity typebox plugin gets updated to support newer versions of typebox we would need to manually update the semver range as done in this pr. But this approach is better then to force it using a resolution.