### PR TITLE
fix(processor): fix the tax rate to taxPercentage converter logic to take into account decimal rates

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@adyen/api-library": "24.0.0",
         "@commercetools-backend/loggers": "22.41.0",
-        "@commercetools/connect-payments-sdk": "0.18.1",
+        "@commercetools/connect-payments-sdk": "0.19.0",
         "@fastify/autoload": "6.1.0",
         "@fastify/cors": "10.0.2",
         "@fastify/formbody": "8.0.2",
@@ -835,12 +835,11 @@
       }
     },
     "node_modules/@commercetools/connect-payments-sdk": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.18.1.tgz",
-      "integrity": "sha512-bPLaN4BJ2n86qCEWPgGDZfWOyLEOWxBAhnKdfTPqmYiJNCBAtNXnvWZ6vDexTfpaC0mUseV8Gzp9RHaC2NqbxQ==",
-      "license": "ISC",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.19.0.tgz",
+      "integrity": "sha512-871jUtt0JLlxi/q4SuGLLsjk8DgYv/WRsBagat1qjj49zOK2OkZt7cJQWsIhX1A2FFpEPo6cQpvYSgDlrtOV2Q==",
       "dependencies": {
-        "@commercetools-backend/loggers": "22.39.1",
+        "@commercetools-backend/loggers": "22.41.0",
         "@commercetools/platform-sdk": "8.1.0",
         "@commercetools/sdk-client-v2": "2.5.0",
         "jsonwebtoken": "9.0.2",
@@ -850,10 +849,9 @@
       }
     },
     "node_modules/@commercetools/connect-payments-sdk/node_modules/@commercetools-backend/loggers": {
-      "version": "22.39.1",
-      "resolved": "https://registry.npmjs.org/@commercetools-backend/loggers/-/loggers-22.39.1.tgz",
-      "integrity": "sha512-fBJQ0vBlZ5lzJDOHwlGLjnxl+xAadVLwZPSPfOlzQ8ETX+N8xbfj6MO94PWo2LRtTZVasGSIf/UKO5fmCZjq3g==",
-      "license": "MIT",
+      "version": "22.41.0",
+      "resolved": "https://registry.npmjs.org/@commercetools-backend/loggers/-/loggers-22.41.0.tgz",
+      "integrity": "sha512-kbtGpnTPu7L6UUzclk8JEwHywt0s4/UUtebIS2925me6nR0GjkfumcsUapd4PtlYoc+BHj+AkRkLjInxRii8wQ==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "@babel/runtime-corejs3": "^7.22.15",
@@ -871,7 +869,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
       "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
-      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -8736,11 +8733,11 @@
       }
     },
     "@commercetools/connect-payments-sdk": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.18.1.tgz",
-      "integrity": "sha512-bPLaN4BJ2n86qCEWPgGDZfWOyLEOWxBAhnKdfTPqmYiJNCBAtNXnvWZ6vDexTfpaC0mUseV8Gzp9RHaC2NqbxQ==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/connect-payments-sdk/-/connect-payments-sdk-0.19.0.tgz",
+      "integrity": "sha512-871jUtt0JLlxi/q4SuGLLsjk8DgYv/WRsBagat1qjj49zOK2OkZt7cJQWsIhX1A2FFpEPo6cQpvYSgDlrtOV2Q==",
       "requires": {
-        "@commercetools-backend/loggers": "22.39.1",
+        "@commercetools-backend/loggers": "22.41.0",
         "@commercetools/platform-sdk": "8.1.0",
         "@commercetools/sdk-client-v2": "2.5.0",
         "jsonwebtoken": "9.0.2",
@@ -8750,9 +8747,9 @@
       },
       "dependencies": {
         "@commercetools-backend/loggers": {
-          "version": "22.39.1",
-          "resolved": "https://registry.npmjs.org/@commercetools-backend/loggers/-/loggers-22.39.1.tgz",
-          "integrity": "sha512-fBJQ0vBlZ5lzJDOHwlGLjnxl+xAadVLwZPSPfOlzQ8ETX+N8xbfj6MO94PWo2LRtTZVasGSIf/UKO5fmCZjq3g==",
+          "version": "22.41.0",
+          "resolved": "https://registry.npmjs.org/@commercetools-backend/loggers/-/loggers-22.41.0.tgz",
+          "integrity": "sha512-kbtGpnTPu7L6UUzclk8JEwHywt0s4/UUtebIS2925me6nR0GjkfumcsUapd4PtlYoc+BHj+AkRkLjInxRii8wQ==",
           "requires": {
             "@babel/runtime": "^7.22.15",
             "@babel/runtime-corejs3": "^7.22.15",

--- a/processor/package.json
+++ b/processor/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@adyen/api-library": "24.0.0",
     "@commercetools-backend/loggers": "22.41.0",
-    "@commercetools/connect-payments-sdk": "0.18.1",
+    "@commercetools/connect-payments-sdk": "0.19.0",
     "@fastify/autoload": "6.1.0",
     "@fastify/cors": "10.0.2",
     "@fastify/formbody": "8.0.2",

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -1,5 +1,3 @@
-import { GenericIssuerPaymentMethodDetails } from '@adyen/api-library/lib/src/typings/checkout/genericIssuerPaymentMethodDetails';
-
 /**
  * Specific configuration for payment methods that require special handling.
  * See https://docs.adyen.com/payment-methods for more information about each payment method.

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -27,10 +27,7 @@ export const mapCoCoLineItemToAdyenLineItem = (lineItem: CoCoLineItem): LineItem
     amountExcludingTax: getItemAmount(getAmountExcludingTax(lineItem), lineItem.quantity),
     amountIncludingTax: getItemAmount(getAmountIncludingTax(lineItem), lineItem.quantity),
     taxAmount: getItemAmount(getTaxAmount(lineItem), lineItem.quantity),
-    taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(
-      lineItem.totalPrice.fractionDigits,
-      lineItem.taxRate?.amount,
-    ),
+    taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(lineItem.taxRate?.amount),
   };
 };
 
@@ -42,10 +39,7 @@ export const mapCoCoCustomLineItemToAdyenLineItem = (customLineItem: CustomLineI
     amountExcludingTax: getItemAmount(getAmountExcludingTax(customLineItem), customLineItem.quantity),
     amountIncludingTax: getItemAmount(getAmountIncludingTax(customLineItem), customLineItem.quantity),
     taxAmount: getItemAmount(getTaxAmount(customLineItem), customLineItem.quantity),
-    taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(
-      customLineItem.totalPrice.fractionDigits,
-      customLineItem.taxRate?.amount,
-    ),
+    taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(customLineItem.taxRate?.amount),
   };
 };
 
@@ -84,10 +78,7 @@ export const mapCoCoShippingInfoToAdyenLineItem = (normalizedShippings: Normaliz
       amountExcludingTax: amountExcludingTaxValue,
       amountIncludingTax: amountIncludingTaxValue,
       taxAmount: taxAmountValue,
-      taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(
-        shipping.shippingInfo.price.fractionDigits,
-        shipping.shippingInfo.taxRate?.amount,
-      ),
+      taxPercentage: TaxRateConverter.convertCoCoTaxPercentage(shipping.shippingInfo.taxRate?.amount),
     };
   });
 };
@@ -169,23 +160,23 @@ export const mapCoCoCartItemsToAdyenLineItems = (
     | 'discountOnTotalPrice'
   >,
 ): LineItem[] => {
-  const aydenLineItems: LineItem[] = [];
+  const adyenLineItems: LineItem[] = [];
 
-  cart.lineItems.forEach((lineItem) => aydenLineItems.push(mapCoCoLineItemToAdyenLineItem(lineItem)));
+  cart.lineItems.forEach((lineItem) => adyenLineItems.push(mapCoCoLineItemToAdyenLineItem(lineItem)));
 
   cart.customLineItems.forEach((customLineItem) =>
-    aydenLineItems.push(mapCoCoCustomLineItemToAdyenLineItem(customLineItem)),
+    adyenLineItems.push(mapCoCoCustomLineItemToAdyenLineItem(customLineItem)),
   );
 
-  aydenLineItems.push(...mapCoCoShippingInfoToAdyenLineItem(paymentSDK.ctCartService.getNormalizedShipping({ cart })));
+  adyenLineItems.push(...mapCoCoShippingInfoToAdyenLineItem(paymentSDK.ctCartService.getNormalizedShipping({ cart })));
 
   if (cart.discountOnTotalPrice) {
-    aydenLineItems.push(
+    adyenLineItems.push(
       mapCoCoDiscountOnTotalPriceToAdyenLineItem({ discountOnTotalPrice: cart.discountOnTotalPrice }),
     );
   }
 
-  return aydenLineItems;
+  return adyenLineItems;
 };
 
 export const populateCartAddress = (address?: CartAddress): Address => {

--- a/processor/test/services/converters/helper.converter.spec.ts
+++ b/processor/test/services/converters/helper.converter.spec.ts
@@ -264,7 +264,6 @@ describe('helper.converter', () => {
   });
 
   test('should map the CoCo line items to Adyen line items taking into account Adyen deviations', () => {
-    // TODO: SCC-2901: once answer given from Adyen, adjust this unit-test accordingly.
     // CLP currencyCode according to ISO_4217 has 0 fractionDigits but Adyen expects 2 fractionDigits
     const input = CoCoCartCLPJSON.lineItems as CoCoLineItem[];
 
@@ -276,7 +275,7 @@ describe('helper.converter', () => {
       amountExcludingTax: 13400,
       amountIncludingTax: 15000,
       taxAmount: 1600,
-      taxPercentage: 12,
+      taxPercentage: 1200,
     };
 
     expect(actual).toEqual(expected);

--- a/processor/test/services/converters/helper.converter.spec.ts
+++ b/processor/test/services/converters/helper.converter.spec.ts
@@ -264,6 +264,7 @@ describe('helper.converter', () => {
   });
 
   test('should map the CoCo line items to Adyen line items taking into account Adyen deviations', () => {
+    // TODO: SCC-2901: once answer given from Adyen, adjust this unit-test accordingly.
     // CLP currencyCode according to ISO_4217 has 0 fractionDigits but Adyen expects 2 fractionDigits
     const input = CoCoCartCLPJSON.lineItems as CoCoLineItem[];
 
@@ -275,7 +276,7 @@ describe('helper.converter', () => {
       amountExcludingTax: 13400,
       amountIncludingTax: 15000,
       taxAmount: 1600,
-      taxPercentage: 1200,
+      taxPercentage: 12,
     };
 
     expect(actual).toEqual(expected);


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-2901

### Description

Previously when I implemented the [fraction digits support in Adyen](https://github.com/commercetools/connect-payment-integration-adyen/pull/288) I made the mistake to re-use the `CurrencyConverters` for the tax rate values as well. Thinking that the logic is the same. However there is one crucial difference. The input for the currency amounts is always integer values but for the tax rate it's possible to have decimal values.

Explicit validations on integers values where added to the `connect-payments-sdk` in `v18` and the package was bumped by [dependabot](https://github.com/commercetools/connect-payment-integration-adyen/pull/308) on 3 of Feb.

This PR uses a new converter function from the https://github.com/commercetools/connect-payments-sdk/pull/317 to handle the line item tax rate amount properly.

### Adyen support response to format requirements

I double checked with Adyen support to see in what format we are suppose to send that tax percentage information. This is what they said:

```
The minor units for the taxPercentage in the lineItem array is always the same, no matter the currency. 
The documentation I had sent is only for the amount.value depending on the currency. 
 
So if you have a tax of 15%, no matter the currency, your lineItems will look like:
  "lineItems" : [
      {
         "id" : "24887",
         "amountExcludingTax" : 2935,
         "amountIncludingTax" : 3199,
         "taxAmount" : 264,
         "description" : "Description",
         "quantity" : 1,
         "taxPercentage" : 1500,
         "productUrl" : "URL",
         "imageUrl" : "URL"
      }
   ],
```

<details>
<summary>Example Austria Klarna sessions/payments api call with a `0.077` (7.7%) tax rate configured in CoCo</summary>

CoCo Payment ID: `ed499007-4040-4e69-b834-d8af61fa0328`. These are the lint items that we send to Adyen as part of the `/sessions` and/or `/payments` request.

```json
  "lineItems": [
    {
      "amountExcludingTax": 147539,
      "amountIncludingTax": 158900,
      "description": "Walnut Cabinet",
      "id": "WCS-09",
      "quantity": 1,
      "taxAmount": 11361,
      "taxPercentage": 770
    },
    {
      "amountExcludingTax": 31490,
      "amountIncludingTax": 33915,
      "description": "Emerald Velvet Chair",
      "id": "VARM-09",
      "quantity": 1,
      "taxAmount": 2425,
      "taxPercentage": 770
    },
    {
      "amountExcludingTax": 185,
      "amountIncludingTax": 199,
      "description": "Wine Bottle Opener",
      "id": "WOP-09",
      "quantity": 1,
      "taxAmount": 14,
      "taxPercentage": 770
    },
    {
      "amountExcludingTax": 0,
      "amountIncludingTax": 0,
      "description": "Shipping - ddelizia-delivery",
      "quantity": 1,
      "taxAmount": 0,
      "taxPercentage": 770
    }
```
</details>

<details>
<summary>Example Austria Klarna sessions/payments api call with a `0.1` (10%) tax rate configured in CoCo</summary>

CoCo Payment ID: `893a5f05-330d-49fe-bcf4-e09d318eb476`. These are the lint items that we send to Adyen as part of the `/sessions` and/or `/payments` request.


```json
  "lineItems": [
    {
      "amountExcludingTax": 817,
      "amountIncludingTax": 899,
      "description": "Willow Teapot",
      "id": "WTP-09",
      "quantity": 1,
      "taxAmount": 82,
      "taxPercentage": 1000
    },
    {
      "amountExcludingTax": 181,
      "amountIncludingTax": 199,
      "description": "Wine Bottle Opener",
      "id": "WOP-09",
      "quantity": 1,
      "taxAmount": 18,
      "taxPercentage": 1000
    },
    {
      "amountExcludingTax": 0,
      "amountIncludingTax": 0,
      "description": "Shipping - Standard Delivery",
      "quantity": 1,
      "taxAmount": 0,
      "taxPercentage": 1000
    }
  ],
```
</details>