### PR TITLE
feat(payments): add support for MobilePay

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     env_file:
       - ./processor/.env
     environment:
-      - CTP_JWKS_URL=http://jwt-server:9000/jwt/.well-known/jwks.json
+      - CTP_JWKS_URL=http://jwt-server:9002/jwt/.well-known/jwks.json
       - CTP_JWT_ISSUER=https://issuer.com
     command: /bin/sh -c 'npm install && npm run watch'
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
     env_file:
       - ./processor/.env
     environment:
-      - CTP_JWKS_URL=http://jwt-server:9002/jwt/.well-known/jwks.json
+      - CTP_JWKS_URL=http://jwt-server:9000/jwt/.well-known/jwks.json
       - CTP_JWT_ISSUER=https://issuer.com
     command: /bin/sh -c 'npm install && npm run watch'
     ports:

--- a/enabler/dev-utils/session.js
+++ b/enabler/dev-utils/session.js
@@ -5,7 +5,7 @@ const fetchAdminToken = async () => {
 
   myHeaders.append(
     "Authorization",
-    `Basic ${btoa(`${__VITE_CTP_CLIENT_ID__}:${__VITE_CTP_CLIENT_SECRET__}`)}`
+    `Basic ${btoa(`${__VITE_CTP_CLIENT_ID__}:${__VITE_CTP_CLIENT_SECRET__}`)}`,
   );
   myHeaders.append("Content-Type", "application/x-www-form-urlencoded");
 
@@ -63,6 +63,7 @@ const getSessionId = async (cartId, isDropin = false) => {
         "swish",
         "twint",
         "vipps",
+        "mobilepay",
       ], // add here your allowed methods for development purposes
     }),
   };

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -205,6 +205,7 @@
                     "swish",
                     "twint",
                     "vipps",
+                    "mobilepay",
                   ];
                   const isAvailable = await component.isAvailable();
                   if (

--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -10,6 +10,9 @@ import {
   Twint,
   SepaDirectDebit,
   Blik,
+  Swish,
+  Vipps,
+  OnlineBankingPL,
 } from "@adyen/adyen-web";
 import {
   ComponentOptions,
@@ -29,7 +32,10 @@ type AdyenComponent =
   | Twint
   | Redirect
   | SepaDirectDebit
-  | Blik;
+  | Blik
+  | Vipps
+  | OnlineBankingPL
+  | Swish;
 
 /**
  * Base Web Component

--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -19,12 +19,24 @@ import {
 } from "../payment-enabler/payment-enabler";
 import { BaseOptions } from "../payment-enabler/adyen-payment-enabler";
 
-type AdyenComponent = Card | PayPal | ApplePay | GooglePay | Klarna | EPS | Twint | Redirect | SepaDirectDebit | Blik;
+type AdyenComponent =
+  | Card
+  | PayPal
+  | ApplePay
+  | GooglePay
+  | Klarna
+  | EPS
+  | Twint
+  | Redirect
+  | SepaDirectDebit
+  | Blik;
 
 /**
  * Base Web Component
  */
-export abstract class AdyenBaseComponentBuilder implements PaymentComponentBuilder {
+export abstract class AdyenBaseComponentBuilder
+  implements PaymentComponentBuilder
+{
   public componentHasSubmit = true;
 
   protected paymentMethod: PaymentMethod;
@@ -96,7 +108,7 @@ export abstract class DefaultAdyenComponent implements PaymentComponent {
 
   private isPaymentMethodAllowed(): boolean {
     return this.adyenCheckout.paymentMethodsResponse.paymentMethods.some(
-      (paymentMethod) => paymentMethod.type === this.paymentMethod
+      (paymentMethod) => paymentMethod.type === this.paymentMethod,
     );
   }
 }

--- a/enabler/src/components/payment-methods/mobilepay.ts
+++ b/enabler/src/components/payment-methods/mobilepay.ts
@@ -1,0 +1,57 @@
+import {
+  ComponentOptions,
+  PaymentComponent,
+  PaymentMethod,
+} from "../../payment-enabler/payment-enabler";
+import { AdyenBaseComponentBuilder, DefaultAdyenComponent } from "../base";
+import { BaseOptions } from "../../payment-enabler/adyen-payment-enabler";
+import { Swish, ICore } from "@adyen/adyen-web";
+/**
+ * MobilePay component
+ *
+ * Configuration options:
+ * https://docs.adyen.com/payment-methods/mobilepay/web-component
+ */
+export class MobilePayBuilder extends AdyenBaseComponentBuilder {
+  constructor(baseOptions: BaseOptions) {
+    super(PaymentMethod.mobilepay, baseOptions);
+  }
+
+  build(config: ComponentOptions): PaymentComponent {
+    const mobilePayComponent = new MobilePayComponent({
+      paymentMethod: this.paymentMethod,
+      adyenCheckout: this.adyenCheckout,
+      componentOptions: config,
+      sessionId: this.sessionId,
+      processorUrl: this.processorUrl,
+    });
+    mobilePayComponent.init();
+    return mobilePayComponent;
+  }
+}
+
+export class MobilePayComponent extends DefaultAdyenComponent {
+  constructor(opts: {
+    paymentMethod: PaymentMethod;
+    adyenCheckout: ICore;
+    componentOptions: ComponentOptions;
+    sessionId: string;
+    processorUrl: string;
+  }) {
+    super(opts);
+  }
+
+  init(): void {
+    this.component = new Swish(this.adyenCheckout, {
+      showPayButton: this.componentOptions.showPayButton,
+    });
+  }
+
+  showValidation() {
+    this.component.showValidation();
+  }
+
+  isValid() {
+    return this.component.isValid;
+  }
+}

--- a/enabler/src/components/payment-methods/mobilepay.ts
+++ b/enabler/src/components/payment-methods/mobilepay.ts
@@ -5,7 +5,7 @@ import {
 } from "../../payment-enabler/payment-enabler";
 import { AdyenBaseComponentBuilder, DefaultAdyenComponent } from "../base";
 import { BaseOptions } from "../../payment-enabler/adyen-payment-enabler";
-import { Swish, ICore } from "@adyen/adyen-web";
+import { Redirect, ICore } from "@adyen/adyen-web";
 /**
  * MobilePay component
  *
@@ -42,7 +42,8 @@ export class MobilePayComponent extends DefaultAdyenComponent {
   }
 
   init(): void {
-    this.component = new Swish(this.adyenCheckout, {
+    this.component = new Redirect(this.adyenCheckout, {
+      type: this.paymentMethod,
       showPayButton: this.componentOptions.showPayButton,
     });
   }

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -1,4 +1,8 @@
-import { DropinComponent, DropinOptions, PaymentDropinBuilder } from "../payment-enabler/payment-enabler";
+import {
+  DropinComponent,
+  DropinOptions,
+  PaymentDropinBuilder,
+} from "../payment-enabler/payment-enabler";
 import { BaseOptions } from "../payment-enabler/adyen-payment-enabler";
 import {
   ICore,
@@ -144,15 +148,22 @@ export class DropinComponents implements DropinComponent {
   }
 
   submit(): void {
-    throw new Error("Method not available. Submit is managed by the Dropin component.");
+    throw new Error(
+      "Method not available. Submit is managed by the Dropin component.",
+    );
   }
 
   private overrideOnSubmit() {
     const parentOnSubmit = this.adyenCheckout.options.onSubmit;
 
-    this.adyenCheckout.options.onSubmit = async (state: SubmitData, component: Dropin, actions: SubmitActions) => {
+    this.adyenCheckout.options.onSubmit = async (
+      state: SubmitData,
+      component: Dropin,
+      actions: SubmitActions,
+    ) => {
       const paymentMethod = state.data.paymentMethod.type;
-      const hasOnClick = component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
+      const hasOnClick =
+        component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
       if (!hasOnClick && this.dropinOptions.onPayButtonClick) {
         try {
           await this.dropinOptions.onPayButtonClick();

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -8,7 +8,7 @@ export interface PaymentComponent {
       endDigits?: string;
       brand?: string;
       expiryDate?: string;
-    }
+    };
   };
   isAvailable?(): Promise<boolean>;
 }
@@ -17,7 +17,6 @@ export interface PaymentComponentBuilder {
   componentHasSubmit: boolean;
   build(config: ComponentOptions): PaymentComponent;
 }
-
 
 export type EnablerOptions = {
   processorUrl: string;
@@ -48,6 +47,7 @@ export enum PaymentMethod {
   swish = "swish",
   twint = "twint",
   vipps = "vipps",
+  mobilepay = "mobilepay",
 }
 
 export type PaymentResult =
@@ -93,7 +93,7 @@ export interface PaymentEnabler {
    * @throws {Error}
    */
   createComponentBuilder: (
-    type: string
+    type: string,
   ) => Promise<PaymentComponentBuilder | never>;
 
   /**
@@ -102,6 +102,6 @@ export interface PaymentEnabler {
    * @throws {Error}
    */
   createDropinBuilder: (
-    type: DropinType
+    type: DropinType,
   ) => Promise<PaymentDropinBuilder | never>;
 }

--- a/processor/src/services/converters/payment-components.converter.ts
+++ b/processor/src/services/converters/payment-components.converter.ts
@@ -46,6 +46,9 @@ export class PaymentComponentsConverter {
           type: 'klarna_pay_overtime', // klarna_account
         },
         {
+          type: 'mobilepay',
+        },
+        {
           type: 'paypal',
         },
         {

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -111,12 +111,13 @@ describe('adyen-payment.service', () => {
     expect(result?.components[9]?.type).toStrictEqual('klarna_pay_later');
     expect(result?.components[10]?.type).toStrictEqual('klarna_pay_now');
     expect(result?.components[11]?.type).toStrictEqual('klarna_pay_overtime');
-    expect(result?.components[12]?.type).toStrictEqual('paypal');
-    expect(result?.components[13]?.type).toStrictEqual('przelewy24');
-    expect(result?.components[14]?.type).toStrictEqual('sepadirectdebit');
-    expect(result?.components[15]?.type).toStrictEqual('swish');
-    expect(result?.components[16]?.type).toStrictEqual('twint');
-    expect(result?.components[17]?.type).toStrictEqual('vipps');
+    expect(result?.components[12]?.type).toStrictEqual('mobilepay');
+    expect(result?.components[13]?.type).toStrictEqual('paypal');
+    expect(result?.components[14]?.type).toStrictEqual('przelewy24');
+    expect(result?.components[15]?.type).toStrictEqual('sepadirectdebit');
+    expect(result?.components[16]?.type).toStrictEqual('swish');
+    expect(result?.components[17]?.type).toStrictEqual('twint');
+    expect(result?.components[18]?.type).toStrictEqual('vipps');
   });
 
   test('getStatus', async () => {

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -98,7 +98,7 @@ describe('adyen-payment.service', () => {
 
   test('getSupportedPaymentComponents', async () => {
     const result: SupportedPaymentComponentsSchemaDTO = await paymentService.getSupportedPaymentComponents();
-    expect(result?.components).toHaveLength(18);
+    expect(result?.components).toHaveLength(19);
     expect(result?.components[0]?.type).toStrictEqual('applepay');
     expect(result?.components[1]?.type).toStrictEqual('bancontactcard');
     expect(result?.components[2]?.type).toStrictEqual('bancontactmobile');


### PR DESCRIPTION
**Link to the ticket:** https://commercetools.atlassian.net/browse/SCC-2872

### Summary

Adds the MobilePay support in the enabler and processor.

Corresponding checkout-anywhere SPA PR https://github.com/checkout-anywhere/checkout-anywhere/pull/7484

Below video shows the MobilePay step using a cart for country `FI` and currency `EUR` for both the `web-component` and `dropin` type. 

Note that doing actual payments is not possible on the Adyen test environment. See [the docs on Adyen](https://docs.adyen.com/payment-methods/mobilepay/web-component/#test-and-go-live).



https://github.com/user-attachments/assets/6b21539f-3076-4aa7-85f2-10bd7e078936

