### PR TITLE
chore(processor): update the `README.MD` to indicate all of the required Adyen webhook `event` types

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -1,4 +1,5 @@
 # Payment Integration Processor
+
 This module provides an application based on [commercetools Connect](https://docs.commercetools.com/connect), which is triggered by HTTP requests from Checkout UI for payment operations.
 
 The corresponding payment, cart or order details would be fetched from composable commerce platform, and then be sent to Adyen payment service for various payment operations such as create session and create/capture/cancel/refund payment.
@@ -11,41 +12,59 @@ These instructions will get you up and running on your local machine for develop
 Please run following npm commands under `processor` folder.
 
 #### Install PSP SDK
+
 In case SDK is provided by payment service provider for communication purpose, you can import the SDK by following commands
+
 ```
-$ npm install <psp-sdk>
+npm install <psp-sdk>
 ```
+
 #### Install dependencies
+
 ```
-$ npm install
+npm install
 ```
+
 #### Build the application in local environment. NodeJS source codes are then generated under dist folder
+
 ```
-$ npm run build
+npm run build
 ```
+
 #### Run automation test
+
 ```
-$ npm run test
+npm run test
 ```
+
 #### Run the application in local environment. Remind that the application has been built before it runs
+
 ```
-$ npm run start
+npm run start
 ```
+
 #### Fix the code style
+
 ```
-$ npm run lint:fix
+npm run lint:fix
 ```
+
 #### Verify the code style
+
 ```
-$ npm run lint
+npm run lint
 ```
+
 #### Run post-deploy script in local environment
+
 ```
-$ npm run connector:post-deploy
+npm run connector:post-deploy
 ```
+
 #### Run pre-undeploy script in local environment
+
 ```
-$ npm run connector:pre-undeploy
+npm run connector:pre-undeploy
 ```
 
 ## Running application
@@ -54,10 +73,10 @@ Setup correct environment variables: check `processor/src/config/config.ts` for 
 
 Make sure commercetools client credential have at least the following permissions:
 
-* `manage_payments`
-* `manage_checkout_payment_intents`
-* `view_sessions`
-* `introspect_oauth_tokens`
+- `manage_payments`
+- `manage_checkout_payment_intents`
+- `view_sessions`
+- `introspect_oauth_tokens`
 
 ```
 npm run dev
@@ -65,18 +84,21 @@ npm run dev
 
 ## Authentication
 
-Some of the services have authentication mechanism. 
+Some of the services have authentication mechanism.
 
-* `oauth2`: Relies on commercetools OAuth2 server
-* `session`: Relies on commercetools session service
-* `jwt`: Relies on the jwt token injected by the merchant center via the forward-to proxy
+- `oauth2`: Relies on commercetools OAuth2 server
+- `session`: Relies on commercetools session service
+- `jwt`: Relies on the jwt token injected by the merchant center via the forward-to proxy
 
 ### OAuth2
+
 OAuth2 token can be obtained from commercetools OAuth2 server. It requires API Client created beforehand. For details, please refer to [Requesting an access token using the Composable Commerce OAuth 2.0 service](https://docs.commercetools.com/api/authorization#requesting-an-access-token-using-the-composable-commerce-oauth-20-service).
 
 ### Session
+
 Payment connectors relies on session to be able to share information between `enabler` and `processor`.
 To create session before sharing information between these two modules, please execute following request to commercetools session service
+
 ```
 POST https://session.<region>.commercetools.com/<commercetools-project-key>/sessions
 Authorization: Bearer <oauth token with manage_sessions scope>
@@ -84,7 +106,7 @@ Authorization: Bearer <oauth token with manage_sessions scope>
 {
   "cart": {
     "cartRef": {
-      "id": "<cart-id>" 
+      "id": "<cart-id>"
     }
   },
   "metadata": {
@@ -102,16 +124,20 @@ Afterwards, session ID can be obtained from response, which is necessary to be p
 
 In order to make easy running the application locally, following commands help to build up a jwt mock server:
 
-####Set environment variable to point to the jwksUrl
+#### Set environment variable to point to the jwksUrl
+
 ```
 export CTP_JWKS_URL="http://localhost:9002/jwt/.well-known/jwks.json"
 ```
-####Run the jwt server
+
+#### Run the jwt server
+
 ```
 docker compose up -d
 ```
 
-####Obtain JWT
+#### Obtain JWT
+
 ```
 # Request token
 curl --location 'http://localhost:9002/jwt/token' \
@@ -122,23 +148,47 @@ curl --location 'http://localhost:9002/jwt/token' \
     "https://mc-api.europe-west1.gcp.commercetools.com/claims/project_key": "<commercetools-project-key>"
 }'
 ```
+
 Token can be found in response
+
 ```
 {"token":"<token>"}
 ```
 
-Use the token to authenticate requests protected by JWT: `Authorization: Bearer <token>`. 
+Use the token to authenticate requests protected by JWT: `Authorization: Bearer <token>`.
+
+## Webhooks
+
+Checkout requires a webhook to be configured in Adyen. The webhook needs to have the following types of events enabled:
+
+- `Authorisation`
+- `Expire`
+- `OfferClosed`
+- `Capture`
+- `CaptureFailed`
+- `Cancellation`
+- `Refund`
+- `RefundFailed`
+- `Chargeback`
+
+Any other type of event will be silently ignored.
 
 ## APIs
+
 The processor exposes following endpoints to execute various operations with Adyen platform:
 
 ### Create payment session
+
 It creates payment resource in composable commerce and create Adyen payment session in payment service provider.
+
 #### Endpoint
+
 `POST /sessions`
 
 #### Request Parameters
+
 The request body is same as [adyen checkout create session request](https://docs.adyen.com/api-explorer/Checkout/71/post/sessions#request) except following parameters are not required
+
 - amount
 - merchantAccount
 - countryCode
@@ -152,16 +202,22 @@ The request body is same as [adyen checkout create session request](https://docs
 These parameters are already provided by the cart created in composable commerce platform, therefore they are not required to be provided when calling the endpoint.
 
 #### Response Parameters
-- sessionData: The [adyen checkout create session response](https://docs.adyen.com/api-explorer/Checkout/71/post/sessions#responses) returned by Adyen platform after Adyen session created. 
-- paymentReference : It represents the unique identifier of payment resource created in composable commerce platform. 
+
+- sessionData: The [adyen checkout create session response](https://docs.adyen.com/api-explorer/Checkout/71/post/sessions#responses) returned by Adyen platform after Adyen session created.
+- paymentReference : It represents the unique identifier of payment resource created in composable commerce platform.
 
 ### Create payment
+
 It mainly starts an Ayden payment transaction in payment services provider. If payment reference is absent in request parameters, the endpoint creates payment resource in composable commerce based on data from the cart.
+
 #### Endpoint
+
 `POST /payments`
 
 #### Request Parameters
+
 The request body is same as [adyen checkout create payment request](https://docs.adyen.com/api-explorer/Checkout/71/post/payments#request) except following parameters are not required
+
 - amount
 - additionalAmount
 - merchantAccount
@@ -175,8 +231,9 @@ The request body is same as [adyen checkout create payment request](https://docs
 These parameters are already provided by the cart created in composable commerce platform, therefore they are not required to be provided when calling the endpoint.
 
 #### Response Parameters
-- action: The [action](https://docs.adyen.com/api-explorer/Checkout/69/post/payments#responses-200-action) to be taken in Adyen platform to complete the payment. 
-- resultCode: It represents the [resultCode](https://docs.adyen.com/api-explorer/Checkout/69/post/payments#responses-200-resultCode) of the payment in Adyen platform. 
+
+- action: The [action](https://docs.adyen.com/api-explorer/Checkout/69/post/payments#responses-200-action) to be taken in Adyen platform to complete the payment.
+- resultCode: It represents the [resultCode](https://docs.adyen.com/api-explorer/Checkout/69/post/payments#responses-200-resultCode) of the payment in Adyen platform.
 - threeDS2ResponseData: Response of the 3D Secure 2 authentication.
 - threeDS2Result: Result of the 3D Secure 2 authentication.
 - threeDSPaymentData: Returned by Adyen platform. When it is non-empty, it contains a value that is mandatory parameter as paymentData for payment confirmation in next step.
@@ -184,33 +241,43 @@ These parameters are already provided by the cart created in composable commerce
 - merchantReturnUrl:
 
 ### Confirm payment
+
 Submits details for a payment to Adyen platform to confirm a payment. It is only necessary when the payment is initialized through [create payment](#create-payment)
+
 #### Endpoint
+
 `POST /payments/details`
 
 #### Request Parameters
+
 The request body is same as [adyen checkout create payment details request](The request body is same as [adyen checkout create payment request](https://docs.adyen.com/api-explorer/Checkout/71/post/payments#request)) with following parameters :
+
 - authenticationData: Data for 3DS authentication.
 - details: A collection of result returned from the `/payments` call.
 - paymentData: Encoded payment data returned from the `/payments` call. If `AuthenticationNotRequired` is received as `resultCode` in the `/payments` response, use the `threeDSPaymentData` from the same response. If the `resultCode` is `AuthenticationFinished`, use the `action.paymentData` from the same response.
 
 #### Response Parameters
+
 It returns following attributes in response
-- 
-- 
+
 - paymentReference: Unique identifier of payment resources updated in commercetools composable commerce.
--  
 
 ### Get supported payment components
-Private endpoint protected by JSON Web Token that exposes the payment methods supported by the connector so that checkout application can retrieve the available payment components. 
+
+Private endpoint protected by JSON Web Token that exposes the payment methods supported by the connector so that checkout application can retrieve the available payment components.
+
 #### Endpoint
+
 `GET /operations/payment-components`
 
 #### Request Parameters
+
 N/A
 
 #### Response Parameters
+
 Now the connector supports payment methods such as `card`, `iDEAL`, `PayPal`
+
 ```
 {
     components: [
@@ -228,15 +295,21 @@ Now the connector supports payment methods such as `card`, `iDEAL`, `PayPal`
 ```
 
 ### Get config
+
 Exposes configuration to the frontend such as `clientKey` and `environment`.
+
 #### Endpoint
+
 `GET /operations/config`
 
 #### Request Parameters
+
 N/A
 
 #### Response Parameters
+
 It returns an object with `clientKey` and `environment` as key-value pair as below:
+
 ```
 {
   clientKey: <clientKey>,
@@ -244,23 +317,29 @@ It returns an object with `clientKey` and `environment` as key-value pair as bel
 }
 ```
 
-
 ### Get status
+
 It provides health check feature for checkout front-end so that the correctness of configurations can be verified.
+
 #### Endpoint
+
 `GET /operations/status`
 
 #### Request Parameters
+
 N/A
 
 #### Response Parameters
+
 It returns following attributes in response:
+
 - status: It indicates the health check status. It can be `OK`, `Partially Available` or `Unavailable`
 - timestamp: The timestamp of the status request
 - version: Current version of the payment connector.
 - checks: List of health check result details. It contains health check result with various external system including commercetools composable commerce and Adyen payment services provider.
+
 ```
-    [ 
+    [
         {
             name: <name of external system>
             status: <status with indicator UP or DOWN>
@@ -268,14 +347,21 @@ It returns following attributes in response:
         }
     ]
 ```
-- metadata: It lists a collection of metadata including the name/description of the connector and the version of SDKs used to connect to external system.  
+
+- metadata: It lists a collection of metadata including the name/description of the connector and the version of SDKs used to connect to external system.
+
 ### Modify payment
+
 Private endpoint called by Checkout frontend to support various payment update requests such as cancel/refund/capture payment. It is protected by `manage_checkout_payment_intents` access right of composable commerce OAuth2 token.
+
 #### Endpoint
+
 `POST /operations/payment-intents/{paymentsId}`
 
 #### Request Parameters
+
 The request payload is different based on different update operations:
+
 - Cancel Payment
 
 ```
@@ -287,38 +373,41 @@ The request payload is different based on different update operations:
 ```
 
 - Capture Payment
-    - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5.
-    - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
-    
-    ```
-    {
-        actions: [{
-            action: "capturePayment",
-            amount: {
-                centAmount: <amount>,
-                currencyCode: <currecy code>
-            }
-        }]
-    } 
-    ```
-  
+
+  - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5.
+  - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
+
+  ```
+  {
+      actions: [{
+          action: "capturePayment",
+          amount: {
+              centAmount: <amount>,
+              currencyCode: <currecy code>
+          }
+      }]
+  }
+  ```
+
 - Refund Payment
-    - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5.
-    - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
-    
-    ```
-    {
-        actions: [{
-            action: "refundPayment",
-            amount: {
-                centAmount: <amount>,
-                currencyCode: <currecy code>
-            }
-        }]
-    } 
-    ```
+
+  - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5.
+  - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
+
+  ```
+  {
+      actions: [{
+          action: "refundPayment",
+          amount: {
+              centAmount: <amount>,
+              currencyCode: <currecy code>
+          }
+      }]
+  }
+  ```
 
 #### Response Parameters
+
 ```
 {
     outcome: "approved|rejected|received"
@@ -327,17 +416,21 @@ The request payload is different based on different update operations:
 ```
 
 ### Create Apple Pay payment session
+
 It creates a new Apple Pay payment session. This is used when the merchants use their own Apple Pay certificates instead of the Adyen's Apple Pay certificate as part of the [validate merchant](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaysession/1778021-onvalidatemerchant) process.
 
 #### Endpoint
+
 `POST /applepay-sessions`
 
 #### Request Parameters
+
 ```
 {
-    "validationUrl": "The validation url provided by Adyen" 
+    "validationUrl": "The validation url provided by Adyen"
 }
 ```
 
 #### Response Parameters
+
 It returns an opaque Apple Pay session object as described in the [docs](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/requesting_an_apple_pay_payment_session#3199963)

--- a/processor/README.md
+++ b/processor/README.md
@@ -159,19 +159,19 @@ Use the token to authenticate requests protected by JWT: `Authorization: Bearer 
 
 ## Webhooks
 
-Checkout requires a webhook to be configured in Adyen. The webhook needs to have the following types of events enabled:
+Checkout requires a webhook to be configured in Adyen. The following list of `eventCode` are required:
 
-- `Authorisation`
-- `Expire`
-- `OfferClosed`
-- `Capture`
-- `CaptureFailed`
-- `Cancellation`
-- `Refund`
-- `RefundFailed`
-- `Chargeback`
+- `AUTHORISATION`
+- `EXPIRE`
+- `OFFER_CLOSED`
+- `CAPTURE`
+- `CAPTURE_FAILED`
+- `CANCELLATION`
+- `REFUND`
+- `REFUND_FAILED`
+- `CHARGEBACK`
 
-Any other type of event will be silently ignored.
+Any other type of event will be silently ignored. For more information see the [Adyen webhook-types](https://docs.adyen.com/development-resources/webhooks/webhook-types/) documentation.
 
 ## APIs
 


### PR DESCRIPTION
Updates the `processor/README.MD` with the required set of `event` types that need to be enabled in Adyen webhooks for the connector/Checkout to work. The new section can be found under the `## Webhooks` header.

The list of required `event` types is retrieved from [notification.converter.ts](https://github.com/commercetools/connect-payment-integration-adyen/blob/main/processor/src/services/converters/notification.converter.ts#L22) where all incoming notifications go through.

A IDE plugin also reformatted and fixed some issues in the README.MD hence it's a bit larger then just the new section. Compare the [updated](https://github.com/commercetools/connect-payment-integration-adyen/tree/joey-koster-ct/SCC-3051-add-adyen-webhook-in-readme.md/processor) and the [main](https://github.com/commercetools/connect-payment-integration-adyen/tree/main/processor) one.

For example in `main` branch there is this section `####Set environment variable to point to the jwksUrl` and because there is no spacing between the text and `####` it's literally rendered as such instead of being rendered as a proper header.