### PR TITLE
feat(payments): Add paymentReference to onSuccess and onError callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 .env
 .connect
+.vscode

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -104,7 +104,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
           } else {
             console.error(error.name, error.message, error.stack, component);
           }
-          options.onError && options.onError(error);
+          options.onError && options.onError(error, { paymentReference });
         },
         onSubmit: async (state: SubmitData, component: UIElement, actions: SubmitActions) => {
           try {
@@ -132,7 +132,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
                 component.setStatus("success");
                 options.onComplete && options.onComplete({ isSuccess: true, paymentReference });
               } else {
-                options.onComplete && options.onComplete({ isSuccess: false });
+                options.onComplete && options.onComplete({ isSuccess: false, paymentReference });
                 component.setStatus("error");
               }
             }
@@ -174,7 +174,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
               component.setStatus("success");
               options.onComplete && options.onComplete({ isSuccess: true, paymentReference });
             } else {
-              options.onComplete && options.onComplete({ isSuccess: false });
+              options.onComplete && options.onComplete({ isSuccess: false, paymentReference });
               component.setStatus("error");
             }
             actions.resolve({ resultCode: data.resultCode });

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -25,7 +25,7 @@ export type EnablerOptions = {
   locale?: string;
   onActionRequired?: () => Promise<void>;
   onComplete?: (result: PaymentResult) => void;
-  onError?: (error: any) => void;
+  onError?: (error: any, payload?: { paymentReference?: string }) => void;
 };
 
 export enum PaymentMethod {
@@ -51,7 +51,7 @@ export type PaymentResult =
       isSuccess: true;
       paymentReference: string;
     }
-  | { isSuccess: false };
+  | { isSuccess: false; paymentReference?: string };
 
 export type ComponentOptions = {
   showPayButton?: boolean;

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -25,7 +25,7 @@ export type EnablerOptions = {
   locale?: string;
   onActionRequired?: () => Promise<void>;
   onComplete?: (result: PaymentResult) => void;
-  onError?: (error: any, payload?: { paymentReference?: string }) => void;
+  onError?: (error: any, context?: { paymentReference?: string }) => void;
 };
 
 export enum PaymentMethod {


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3041

Some customer is requesting that we forward the payment reference in failure cases. ATM we're just sending this on success cases, but there's no reason for not sending it on failure cases if available, so we're adding this as a reference