### PR TITLE
chore(dependencies): revert adyen-web upgrade

### DIFF
--- a/enabler/package-lock.json
+++ b/enabler/package-lock.json
@@ -8,7 +8,7 @@
       "name": "enabler",
       "version": "5.6.1",
       "dependencies": {
-        "@adyen/adyen-web": "6.11.0",
+        "@adyen/adyen-web": "6.9.0",
         "serve": "14.2.4"
       },
       "devDependencies": {
@@ -22,12 +22,12 @@
       }
     },
     "node_modules/@adyen/adyen-web": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-6.11.0.tgz",
-      "integrity": "sha512-OSpTq+VN84hNPOV5RpHM8T4TYMgL8sMr0UDa+2yDeTEBTIlNdigCKgDWTXzOHIW/BuPWna4e9n1fuGYnCJgXlQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-6.9.0.tgz",
+      "integrity": "sha512-R4TbMuDT7rzSwpUEmgD/idW/a7x3gMv1LIdvHdwiNOEhJeLyCZTCSZBbP0r9SecpRFN1BM1L57FJc4WZfhRS+w==",
       "license": "MIT",
       "dependencies": {
-        "@types/applepayjs": "14.0.9",
+        "@types/applepayjs": "14.0.8",
         "@types/googlepay": "0.7.6",
         "classnames": "2.5.1",
         "preact": "10.22.1"
@@ -2077,9 +2077,9 @@
       "peer": true
     },
     "node_modules/@types/applepayjs": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.9.tgz",
-      "integrity": "sha512-xEprYbb0TEP/XIiDPbVnTYpDai8fTFpsQfVSfTd81Is2GOMUy7ie019eyX6Mz2ECxfjoUVKaiGSL577roIeHCg==",
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.8.tgz",
+      "integrity": "sha512-Yzf5OSitdS+/G8cjaAkPJ0+pBOEf9Vik1XUCdw6ul7Qh6Xb18wTlG/sWA5jKIme3x4fbyTGlSd4mfkvdtP9mRw==",
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -5966,11 +5966,11 @@
   },
   "dependencies": {
     "@adyen/adyen-web": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-6.11.0.tgz",
-      "integrity": "sha512-OSpTq+VN84hNPOV5RpHM8T4TYMgL8sMr0UDa+2yDeTEBTIlNdigCKgDWTXzOHIW/BuPWna4e9n1fuGYnCJgXlQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-6.9.0.tgz",
+      "integrity": "sha512-R4TbMuDT7rzSwpUEmgD/idW/a7x3gMv1LIdvHdwiNOEhJeLyCZTCSZBbP0r9SecpRFN1BM1L57FJc4WZfhRS+w==",
       "requires": {
-        "@types/applepayjs": "14.0.9",
+        "@types/applepayjs": "14.0.8",
         "@types/googlepay": "0.7.6",
         "classnames": "2.5.1",
         "preact": "10.22.1"
@@ -7267,9 +7267,9 @@
       "peer": true
     },
     "@types/applepayjs": {
-      "version": "14.0.9",
-      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.9.tgz",
-      "integrity": "sha512-xEprYbb0TEP/XIiDPbVnTYpDai8fTFpsQfVSfTd81Is2GOMUy7ie019eyX6Mz2ECxfjoUVKaiGSL577roIeHCg=="
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/@types/applepayjs/-/applepayjs-14.0.8.tgz",
+      "integrity": "sha512-Yzf5OSitdS+/G8cjaAkPJ0+pBOEf9Vik1XUCdw6ul7Qh6Xb18wTlG/sWA5jKIme3x4fbyTGlSd4mfkvdtP9mRw=="
     },
     "@types/babel__core": {
       "version": "7.20.5",

--- a/enabler/package.json
+++ b/enabler/package.json
@@ -12,7 +12,7 @@
     "serve": "npm run build && serve public -l 3000 --cors"
   },
   "dependencies": {
-    "@adyen/adyen-web": "6.11.0",
+    "@adyen/adyen-web": "6.9.0",
     "serve": "14.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
we are having problems loading Apple Pay and we think the issue could be related to the recent upgrade of the adyen-web package.

https://commercetools.atlassian.net/browse/SCC-3107?atlOrigin=eyJpIjoiNDk4YjkyNDQ0YTQyNGUyMjk5ZTM4NDA2ZTdkMjMzZDciLCJwIjoiamlyYS1zbGFjay1pbnQifQ