### PR TITLE
feat(clearpay): add support in enabler and processor

### DIFF
--- a/enabler/dev-utils/session.js
+++ b/enabler/dev-utils/session.js
@@ -65,6 +65,7 @@ const getSessionId = async (cartId, isDropin = false) => {
         "swish",
         "twint",
         "vipps",
+        "clearpay",
       ], // add here your allowed methods for development purposes
     }),
   };

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -207,6 +207,7 @@
                     "vipps",
                     "mobilepay",
                     "afterpay",
+                    "clearpay",
                   ];
                   const isAvailable = await component.isAvailable();
                   if (

--- a/enabler/src/components/payment-methods/clearpay.ts
+++ b/enabler/src/components/payment-methods/clearpay.ts
@@ -1,0 +1,61 @@
+import {
+  ComponentOptions,
+  PaymentComponent,
+  PaymentMethod,
+} from "../../payment-enabler/payment-enabler";
+import { AdyenBaseComponentBuilder, DefaultAdyenComponent } from "../base";
+import { BaseOptions } from "../../payment-enabler/adyen-payment-enabler";
+import { ICore, Redirect } from "@adyen/adyen-web";
+/**
+ * Clearpay component
+ *
+ * Configuration options:
+ * https://docs.adyen.com/payment-methods/clearpay/web-component/
+ */
+export class ClearpayBuilder extends AdyenBaseComponentBuilder {
+  constructor(baseOptions: BaseOptions) {
+    super(PaymentMethod.clearpay, baseOptions);
+  }
+
+  build(config: ComponentOptions): PaymentComponent {
+    const clearpayComponent = new ClearpayComponent({
+      paymentMethod: this.paymentMethod,
+      adyenCheckout: this.adyenCheckout,
+      componentOptions: config,
+      sessionId: this.sessionId,
+      processorUrl: this.processorUrl,
+      paymentComponentConfigOverride:
+        this.resolvePaymentComponentConfigOverride(PaymentMethod.clearpay),
+    });
+    clearpayComponent.init();
+    return clearpayComponent;
+  }
+}
+
+export class ClearpayComponent extends DefaultAdyenComponent {
+  constructor(opts: {
+    paymentMethod: PaymentMethod;
+    adyenCheckout: ICore;
+    componentOptions: ComponentOptions;
+    sessionId: string;
+    processorUrl: string;
+    paymentComponentConfigOverride: Record<string, any>;
+  }) {
+    super(opts);
+  }
+
+  init(): void {
+    this.component = new Redirect(this.adyenCheckout, {
+      type: "clearpay",
+      showPayButton: this.componentOptions.showPayButton,
+    });
+  }
+
+  async showValidation() {
+    this.component.showValidation();
+  }
+
+  async isValid() {
+    return this.component.isValid;
+  }
+}

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -37,7 +37,8 @@ export class DropinEmbeddedBuilder implements PaymentDropinBuilder {
 
   constructor(baseOptions: BaseOptions) {
     this.adyenCheckout = baseOptions.adyenCheckout;
-    this.paymentComponentsConfigOverride = baseOptions.paymentComponentsConfigOverride;
+    this.paymentComponentsConfigOverride =
+      baseOptions.paymentComponentsConfigOverride;
   }
 
   build(config: DropinOptions): DropinComponent {
@@ -62,7 +63,11 @@ export class DropinComponents implements DropinComponent {
   private dropinOptions: DropinOptions;
   private dropinConfigOverride: Record<string, any>;
 
-  constructor(opts: { adyenCheckout: ICore; dropinOptions: DropinOptions; dropinConfigOverride: Record<string, any> }) {
+  constructor(opts: {
+    adyenCheckout: ICore;
+    dropinOptions: DropinOptions;
+    dropinConfigOverride: Record<string, any>;
+  }) {
     this.dropinOptions = opts.dropinOptions;
     this.adyenCheckout = opts.adyenCheckout;
     this.dropinConfigOverride = opts.dropinConfigOverride;
@@ -108,7 +113,9 @@ export class DropinComponents implements DropinComponent {
           buttonType: "pay" as any, // "pay" type is not included in Adyen's types, try to force it
           buttonColor: "black",
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.applepay)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.applepay)
+          ],
           // Configuration that can not be overridden
           onClick: (resolve, reject) => {
             if (this.dropinOptions.onPayButtonClick) {
@@ -122,12 +129,16 @@ export class DropinComponents implements DropinComponent {
         },
         bcmc: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.bancontactcard)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.bancontactcard)
+          ],
           // Configuration that can not be overridden
         },
         bcmc_mobile: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.bancontactmobile)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.bancontactmobile)
+          ],
           // Configuration that can not be overridden
         },
 
@@ -135,14 +146,18 @@ export class DropinComponents implements DropinComponent {
           hasHolderName: true,
           holderNameRequired: true,
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.card)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.card)
+          ],
           // Configuration that can not be overridden
         },
         googlepay: {
           buttonType: "pay",
           buttonSizeMode: "fill",
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.googlepay)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.googlepay)
+          ],
           // Configuration that can not be overridden
           onClick: (resolve, reject) => {
             if (this.dropinOptions.onPayButtonClick) {
@@ -156,27 +171,37 @@ export class DropinComponents implements DropinComponent {
         },
         klarna_b2b: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_billie)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.klarna_billie)
+          ],
           // Configuration that can not be overridden
         },
         klarna: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_later)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.klarna_pay_later)
+          ],
           // Configuration that can not be overridden
         },
         klarna_paynow: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_now)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.klarna_pay_now)
+          ],
           // Configuration that can not be overridden
         },
         klarna_account: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_overtime)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.klarna_pay_overtime)
+          ],
           // Configuration that can not be overridden
         },
         onlineBanking_PL: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.przelewy24)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.przelewy24)
+          ],
           // Configuration that can not be overridden
         },
         paypal: {
@@ -184,7 +209,9 @@ export class DropinComponents implements DropinComponent {
           blockPayPalPayLaterButton: true,
           blockPayPalVenmoButton: true,
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.paypal)],
+          ...this.dropinConfigOverride[
+            getPaymentMethodType(PaymentMethod.paypal)
+          ],
           // Configuration that can not be overridden
           style: {
             disableMaxWidth: true,
@@ -209,15 +236,22 @@ export class DropinComponents implements DropinComponent {
   }
 
   async submit(): Promise<void> {
-    throw new Error("Method not available. Submit is managed by the Dropin component.");
+    throw new Error(
+      "Method not available. Submit is managed by the Dropin component.",
+    );
   }
 
   private overrideOnSubmit() {
     const parentOnSubmit = this.adyenCheckout.options.onSubmit;
 
-    this.adyenCheckout.options.onSubmit = async (state: SubmitData, component: Dropin, actions: SubmitActions) => {
+    this.adyenCheckout.options.onSubmit = async (
+      state: SubmitData,
+      component: Dropin,
+      actions: SubmitActions,
+    ) => {
       const paymentMethod = state.data.paymentMethod.type;
-      const hasOnClick = component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
+      const hasOnClick =
+        component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
       if (!hasOnClick && this.dropinOptions.onPayButtonClick) {
         try {
           await this.dropinOptions.onPayButtonClick();

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -41,6 +41,7 @@ import { VippsBuilder } from "../components/payment-methods/vipps";
 import { MobilePayBuilder } from "../components/payment-methods/mobilepay";
 import { convertToAdyenLocale } from "../converters/locale.converter";
 import { AfterPayBuilder } from "../components/payment-methods/afterpay";
+import { ClearpayBuilder } from "../components/payment-methods/clearpay";
 
 class AdyenInitError extends Error {
   sessionId: string;
@@ -271,7 +272,9 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
     }
   };
 
-  async createComponentBuilder(type: string): Promise<PaymentComponentBuilder | never> {
+  async createComponentBuilder(
+    type: string,
+  ): Promise<PaymentComponentBuilder | never> {
     const setupData = await this.setupData;
     if (!setupData) {
       throw new Error("AdyenPaymentEnabler not initialized");
@@ -297,6 +300,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
       vipps: VippsBuilder,
       mobilepay: MobilePayBuilder,
       afterpay: AfterPayBuilder,
+      clearpay: ClearpayBuilder,
     };
 
     if (!Object.keys(supportedMethods).includes(type)) {

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -26,7 +26,10 @@ export type EnablerOptions = {
   locale?: string;
   onActionRequired?: () => Promise<void>;
   onComplete?: (result: PaymentResult) => void;
-  onError?: (error: any, context?: { paymentReference?: string; method?: { type?: string } }) => void;
+  onError?: (
+    error: any,
+    context?: { paymentReference?: string; method?: { type?: string } },
+  ) => void;
 };
 
 export enum PaymentMethod {
@@ -36,6 +39,7 @@ export enum PaymentMethod {
   bancontactmobile = "bcmc_mobile", // Bancontact mobile
   blik = "blik",
   card = "scheme",
+  clearpay = "clearpay",
   dropin = "dropin",
   eps = "eps",
   googlepay = "googlepay",
@@ -53,7 +57,9 @@ export enum PaymentMethod {
   mobilepay = "mobilepay",
 }
 
-export const getPaymentMethodType = (adyenPaymentMethod: string): PaymentMethod | undefined => {
+export const getPaymentMethodType = (
+  adyenPaymentMethod: string,
+): PaymentMethod | undefined => {
   for (const enumKey in PaymentMethod) {
     if (PaymentMethod[enumKey] === adyenPaymentMethod) {
       return enumKey as PaymentMethod;
@@ -109,12 +115,16 @@ export interface PaymentEnabler {
   /**
    * @throws {Error}
    */
-  createComponentBuilder: (type: string) => Promise<PaymentComponentBuilder | never>;
+  createComponentBuilder: (
+    type: string,
+  ) => Promise<PaymentComponentBuilder | never>;
 
   /**
    *
    * @returns {Promise<DropinComponent>}
    * @throws {Error}
    */
-  createDropinBuilder: (type: DropinType) => Promise<PaymentDropinBuilder | never>;
+  createDropinBuilder: (
+    type: DropinType,
+  ) => Promise<PaymentDropinBuilder | never>;
 }

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -62,6 +62,8 @@ export class CreatePaymentConverter {
           lineItems: mapCoCoCartItemsToAdyenLineItems(cart, data.paymentMethod.type),
         };
       }
+      // clearpay is the same as afterpaytouch
+      case 'clearpay':
       case 'afterpaytouch': {
         return this.populateAfterpayData(cart, data.paymentMethod.type);
       }

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -24,7 +24,7 @@ import { config } from '../../config/config';
 /**
  * These payment methods require product line item discounts to be send seperately as a new (negative value) line item
  */
-export const PAYMENT_METHODS_REQUIRE_SEPERATE_DISCOUNT = ['afterpaytouch'];
+export const PAYMENT_METHODS_REQUIRE_SEPERATE_DISCOUNT = ['afterpaytouch', 'clearpay'];
 
 export const mapCoCoLineItemToAdyenLineItem = (lineItem: CoCoLineItem): LineItem => {
   return {

--- a/processor/src/services/converters/payment-components.converter.ts
+++ b/processor/src/services/converters/payment-components.converter.ts
@@ -69,6 +69,9 @@ export class PaymentComponentsConverter {
         {
           type: 'vipps',
         },
+        {
+          type: 'clearpay',
+        },
       ],
     };
   }

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -98,7 +98,7 @@ describe('adyen-payment.service', () => {
 
   test('getSupportedPaymentComponents', async () => {
     const result: SupportedPaymentComponentsSchemaDTO = await paymentService.getSupportedPaymentComponents();
-    expect(result?.components).toHaveLength(20);
+    expect(result?.components).toHaveLength(21);
     expect(result?.components[0]?.type).toStrictEqual('afterpay');
     expect(result?.components[1]?.type).toStrictEqual('applepay');
     expect(result?.components[2]?.type).toStrictEqual('bancontactcard');
@@ -119,6 +119,7 @@ describe('adyen-payment.service', () => {
     expect(result?.components[17]?.type).toStrictEqual('swish');
     expect(result?.components[18]?.type).toStrictEqual('twint');
     expect(result?.components[19]?.type).toStrictEqual('vipps');
+    expect(result?.components[20]?.type).toStrictEqual('clearpay');
   });
 
   test('getStatus', async () => {


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3398

This PR adds support for the Clearpay payment method which is available for GB customers. This works for both web-components as well as dropins.