### PR TITLE
feat(payments): Support linking refund requests to existing charge transactions

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.11.0",
       "license": "ISC",
       "dependencies": {
-        "@adyen/api-library": "27.0.1",
+        "@adyen/api-library": "28.0.0",
         "@commercetools-backend/loggers": "24.2.1",
         "@commercetools/connect-payments-sdk": "0.23.1",
         "@fastify/autoload": "6.3.1",
@@ -25,7 +25,7 @@
         "fastify-plugin": "5.0.1"
       },
       "devDependencies": {
-        "@commercetools/composable-commerce-test-data": "12.0.0",
+        "@commercetools/composable-commerce-test-data": "12.2.0",
         "@jest/globals": "30.0.4",
         "@types/jest": "30.0.0",
         "@types/node": "24.0.12",
@@ -56,9 +56,10 @@
       }
     },
     "node_modules/@adyen/api-library": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@adyen/api-library/-/api-library-27.0.1.tgz",
-      "integrity": "sha512-FPqD18ArHt1IIaPUVM7JHdyLTE8i9JUoDuSDCUA0Iy5NarTnFBK2FXHARuymWsfvpjHal+2+1/RlRiaUVsF8Bg==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@adyen/api-library/-/api-library-28.0.0.tgz",
+      "integrity": "sha512-qgAa+WLrIkapJaXlqtJY9reHeoM4NYq9UzChU+VAgC2tnXLOnhoYKzoxHbmRd8U2JsN87Zdk63oMIF5DIIZfXg==",
+      "license": "MIT",
       "dependencies": {
         "https-proxy-agent": "5.0.1"
       },
@@ -748,9 +749,9 @@
       }
     },
     "node_modules/@commercetools-frontend/application-config": {
-      "version": "22.42.1",
-      "resolved": "https://registry.npmjs.org/@commercetools-frontend/application-config/-/application-config-22.42.1.tgz",
-      "integrity": "sha512-xt0qVpwpmMflRvea2NtE4/wrdADGrmCpHxSPu+3m1RxgVpSPG974mgprYxbR+O2YmXRaYDFy2ErCPVfvyZJ8cw==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@commercetools-frontend/application-config/-/application-config-24.2.1.tgz",
+      "integrity": "sha512-OTn7OoF/FDsDQC95JmLalkd6Hd6tFZhTMg1DzeDpsQSvDdYQsh3TAMW1pJiUpK8HXOx4rq+IV0sBY80zbRJlJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -758,21 +759,20 @@
         "@babel/register": "^7.22.15",
         "@babel/runtime": "^7.22.15",
         "@babel/runtime-corejs3": "^7.22.15",
-        "@commercetools-frontend/constants": "22.42.1",
-        "@types/dompurify": "^2.4.0",
+        "@commercetools-frontend/constants": "24.2.1",
         "@types/lodash": "^4.14.198",
-        "@types/react": "^17.0.83",
+        "@types/react": "^19.0.3",
         "ajv": "8.16.0",
         "core-js": "^3.32.2",
         "cosmiconfig": "9.0.0",
         "cosmiconfig-typescript-loader": "6.1.0",
-        "dompurify": "^2.4.7",
+        "dompurify": "^3.0.0",
         "jsdom": "^21.1.2",
         "lodash": "4.17.21",
         "omit-empty-es": "1.2.0"
       },
       "engines": {
-        "node": "16.x || >=18.0.0"
+        "node": "18.x || 20.x || >=22.0.0"
       }
     },
     "node_modules/@commercetools-frontend/application-config/node_modules/ajv": {
@@ -800,9 +800,9 @@
       "license": "MIT"
     },
     "node_modules/@commercetools-frontend/constants": {
-      "version": "22.42.1",
-      "resolved": "https://registry.npmjs.org/@commercetools-frontend/constants/-/constants-22.42.1.tgz",
-      "integrity": "sha512-6+CfJwqbaiF79Y5GlmNiIS320Q/2AwFnkap8Q60a5mUeLwxEC9yT5Pz/KHFdrta9IeZRm8rH2QADyUz8KNz6PA==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@commercetools-frontend/constants/-/constants-24.2.1.tgz",
+      "integrity": "sha512-V3eJSoSJ5fuZUAvbTDAjsK6VJGX6NQTitoBTfge7Ev9OTTCK+X9WxClQAfYlQnd4lSBnWOsGLOfatcfWj+RmGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -811,15 +811,16 @@
       }
     },
     "node_modules/@commercetools/composable-commerce-test-data": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/composable-commerce-test-data/-/composable-commerce-test-data-12.0.0.tgz",
-      "integrity": "sha512-IPaQlxwIGvuYglQFoRvpZzF7TK1adLW+6gfFji+2sKKLvsqoXSK5FrbnhfLRrdAgAvVlXREAVznZ3/lMv8t19g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/composable-commerce-test-data/-/composable-commerce-test-data-12.2.0.tgz",
+      "integrity": "sha512-+1H6tRDl13FU5KWjwWy+qLcjLLQ9TE6uezqpCNUyToo+Gc1CW37eMBoKxOjqynwpB4x0QxwGNTwb09uw618seQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.9",
         "@babel/runtime-corejs3": "^7.17.9",
-        "@commercetools-frontend/application-config": "^22.10.0",
-        "@commercetools-frontend/constants": "^22.10.0",
+        "@commercetools-frontend/application-config": "^24.0.0",
+        "@commercetools-frontend/constants": "^24.0.0",
         "@commercetools/platform-sdk": "8.8.0",
         "@faker-js/faker": "^9.0.0",
         "@types/lodash": "^4.17.0",
@@ -1152,14 +1153,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2445,16 +2459,6 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true
     },
-    "node_modules/@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -2568,13 +2572,6 @@
         "undici-types": "~7.8.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -2588,23 +2585,14 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.87",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.87.tgz",
-      "integrity": "sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -2655,7 +2643,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -3979,9 +3968,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4126,9 +4115,9 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4213,11 +4202,14 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "dev": true,
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.2.0",
@@ -5367,9 +5359,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5421,6 +5413,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5690,6 +5683,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9579,9 +9573,9 @@
       "dev": true
     },
     "@adyen/api-library": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/@adyen/api-library/-/api-library-27.0.1.tgz",
-      "integrity": "sha512-FPqD18ArHt1IIaPUVM7JHdyLTE8i9JUoDuSDCUA0Iy5NarTnFBK2FXHARuymWsfvpjHal+2+1/RlRiaUVsF8Bg==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@adyen/api-library/-/api-library-28.0.0.tgz",
+      "integrity": "sha512-qgAa+WLrIkapJaXlqtJY9reHeoM4NYq9UzChU+VAgC2tnXLOnhoYKzoxHbmRd8U2JsN87Zdk63oMIF5DIIZfXg==",
       "requires": {
         "@types/node": "18.19.69",
         "https-proxy-agent": "5.0.1"
@@ -10080,24 +10074,23 @@
       }
     },
     "@commercetools-frontend/application-config": {
-      "version": "22.42.1",
-      "resolved": "https://registry.npmjs.org/@commercetools-frontend/application-config/-/application-config-22.42.1.tgz",
-      "integrity": "sha512-xt0qVpwpmMflRvea2NtE4/wrdADGrmCpHxSPu+3m1RxgVpSPG974mgprYxbR+O2YmXRaYDFy2ErCPVfvyZJ8cw==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@commercetools-frontend/application-config/-/application-config-24.2.1.tgz",
+      "integrity": "sha512-OTn7OoF/FDsDQC95JmLalkd6Hd6tFZhTMg1DzeDpsQSvDdYQsh3TAMW1pJiUpK8HXOx4rq+IV0sBY80zbRJlJg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.22.17",
         "@babel/register": "^7.22.15",
         "@babel/runtime": "^7.22.15",
         "@babel/runtime-corejs3": "^7.22.15",
-        "@commercetools-frontend/constants": "22.42.1",
-        "@types/dompurify": "^2.4.0",
+        "@commercetools-frontend/constants": "24.2.1",
         "@types/lodash": "^4.14.198",
-        "@types/react": "^17.0.83",
+        "@types/react": "^19.0.3",
         "ajv": "8.16.0",
         "core-js": "^3.32.2",
         "cosmiconfig": "9.0.0",
         "cosmiconfig-typescript-loader": "6.1.0",
-        "dompurify": "^2.4.7",
+        "dompurify": "^3.0.0",
         "jsdom": "^21.1.2",
         "lodash": "4.17.21",
         "omit-empty-es": "1.2.0"
@@ -10124,9 +10117,9 @@
       }
     },
     "@commercetools-frontend/constants": {
-      "version": "22.42.1",
-      "resolved": "https://registry.npmjs.org/@commercetools-frontend/constants/-/constants-22.42.1.tgz",
-      "integrity": "sha512-6+CfJwqbaiF79Y5GlmNiIS320Q/2AwFnkap8Q60a5mUeLwxEC9yT5Pz/KHFdrta9IeZRm8rH2QADyUz8KNz6PA==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@commercetools-frontend/constants/-/constants-24.2.1.tgz",
+      "integrity": "sha512-V3eJSoSJ5fuZUAvbTDAjsK6VJGX6NQTitoBTfge7Ev9OTTCK+X9WxClQAfYlQnd4lSBnWOsGLOfatcfWj+RmGQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.22.15",
@@ -10134,15 +10127,15 @@
       }
     },
     "@commercetools/composable-commerce-test-data": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/composable-commerce-test-data/-/composable-commerce-test-data-12.0.0.tgz",
-      "integrity": "sha512-IPaQlxwIGvuYglQFoRvpZzF7TK1adLW+6gfFji+2sKKLvsqoXSK5FrbnhfLRrdAgAvVlXREAVznZ3/lMv8t19g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/composable-commerce-test-data/-/composable-commerce-test-data-12.2.0.tgz",
+      "integrity": "sha512-+1H6tRDl13FU5KWjwWy+qLcjLLQ9TE6uezqpCNUyToo+Gc1CW37eMBoKxOjqynwpB4x0QxwGNTwb09uw618seQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.9",
         "@babel/runtime-corejs3": "^7.17.9",
-        "@commercetools-frontend/application-config": "^22.10.0",
-        "@commercetools-frontend/constants": "^22.10.0",
+        "@commercetools-frontend/application-config": "^24.0.0",
+        "@commercetools-frontend/constants": "^24.0.0",
         "@commercetools/platform-sdk": "8.8.0",
         "@faker-js/faker": "^9.0.0",
         "@types/lodash": "^4.17.0",
@@ -10413,13 +10406,24 @@
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "requires": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
+      },
+      "dependencies": {
+        "@eslint/core": {
+          "version": "0.15.1",
+          "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+          "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.15"
+          }
+        }
       }
     },
     "@faker-js/faker": {
@@ -11361,15 +11365,6 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "dev": true
     },
-    "@types/dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-IDBwO5IZhrKvHFUl+clZxgf3hn2b/lU6H1KaBShPkQyGJUQ0xwebezIPSuiyGwfz1UzJWQl4M7BDxtHtCCPlTg==",
-      "dev": true,
-      "requires": {
-        "@types/trusted-types": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -11475,12 +11470,6 @@
         "undici-types": "~7.8.0"
       }
     },
-    "@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
-    },
     "@types/qs": {
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
@@ -11492,21 +11481,13 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/react": {
-      "version": "17.0.87",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.87.tgz",
-      "integrity": "sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
       "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
     },
     "@types/send": {
       "version": "0.17.4",
@@ -11554,7 +11535,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/yargs": {
       "version": "17.0.33",
@@ -12426,9 +12408,9 @@
       "integrity": "sha512-Xd8lFX4LM9QEEwxQpF9J9NTUh8pmdJO0cyRJhFiDoLTk2eH8FXlRv2IFGYVadZpqI3j8fhNrSdKCeYPxiAhLXw=="
     },
     "core-js": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw==",
       "dev": true
     },
     "core-js-pure": {
@@ -12514,9 +12496,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
     },
     "dedent": {
@@ -12571,10 +12553,13 @@
       }
     },
     "dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "dev": true
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "dotenv": {
       "version": "17.2.0",
@@ -13376,9 +13361,9 @@
       }
     },
     "form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",

--- a/processor/package.json
+++ b/processor/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@adyen/api-library": "27.0.1",
+    "@adyen/api-library": "28.0.0",
     "@commercetools-backend/loggers": "24.2.1",
     "@commercetools/connect-payments-sdk": "0.23.1",
     "@fastify/autoload": "6.3.1",
@@ -37,7 +37,7 @@
     "fastify-plugin": "5.0.1"
   },
   "devDependencies": {
-    "@commercetools/composable-commerce-test-data": "12.0.0",
+    "@commercetools/composable-commerce-test-data": "12.2.0",
     "@jest/globals": "30.0.4",
     "@types/jest": "30.0.0",
     "@types/node": "24.0.12",

--- a/processor/src/dtos/operations/payment-intents.dto.ts
+++ b/processor/src/dtos/operations/payment-intents.dto.ts
@@ -22,6 +22,7 @@ export const ActionRefundPaymentSchema = Type.Composite([
   Type.Object({
     amount: AmountSchema,
     merchantReference: Type.Optional(Type.String()),
+    transactionId: Type.Optional(Type.String()),
   }),
 ]);
 

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -105,6 +105,7 @@ export abstract class AbstractPaymentService {
           amount: request.amount,
           payment: ctPayment,
           merchantReference: request.merchantReference,
+          transactionId: request.transactionId,
         });
       }
       case 'reversePayment': {

--- a/processor/src/services/converters/refund-payment.converter.ts
+++ b/processor/src/services/converters/refund-payment.converter.ts
@@ -1,11 +1,12 @@
 import { config } from '../../config/config';
 import { PaymentRefundRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRefundRequest';
 import { RefundPaymentRequest } from '../types/operation.type';
-import { CurrencyConverters } from '@commercetools/connect-payments-sdk';
+import { CurrencyConverters, Errorx, Payment, Transaction } from '@commercetools/connect-payments-sdk';
 import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
 
 export class RefundPaymentConverter {
   public convertRequest(opts: RefundPaymentRequest): PaymentRefundRequest {
+    const capturePspReference = this.getCapturePspReference(opts.payment, opts.transactionId);
     return {
       merchantAccount: config.adyenMerchantAccount,
       reference: opts.merchantReference || opts.payment.id,
@@ -17,6 +18,41 @@ export class RefundPaymentConverter {
           currencyCode: opts.amount.currencyCode,
         }),
       },
+      ...(capturePspReference && { capturePspReference }),
     };
+  }
+
+  private getTransaction(payment: Payment, transactionId: string): Transaction {
+    const transaction = payment.transactions.find((tx) => tx.id === transactionId);
+    if (!transaction) {
+      throw new Errorx({
+        httpErrorStatus: 400,
+        code: 'InvalidInput',
+        message: `Transaction with ID '${transactionId}' does not exist`,
+      });
+    }
+
+    if (transaction.type !== 'Charge') {
+      throw new Errorx({
+        httpErrorStatus: 400,
+        code: 'InvalidInput',
+        message: `Transaction with ID '${transactionId}' must be of type 'Charge'`,
+      });
+    }
+
+    return transaction;
+  }
+
+  private getCapturePspReference(payment: Payment, transactionId?: string): string | undefined {
+    if (!transactionId || !this.isPaypalPayment(payment)) {
+      return undefined;
+    }
+
+    const transaction = this.getTransaction(payment, transactionId);
+    return transaction.interactionId;
+  }
+
+  private isPaypalPayment(payment: Payment): boolean {
+    return payment.paymentMethodInfo?.method === 'paypal';
   }
 }

--- a/processor/src/services/types/operation.type.ts
+++ b/processor/src/services/types/operation.type.ts
@@ -22,6 +22,7 @@ export type RefundPaymentRequest = {
   amount: AmountSchemaDTO;
   payment: Payment;
   merchantReference?: string;
+  transactionId?: string;
 };
 
 export type ReversePaymentRequest = {

--- a/processor/test/services/converters/refund.converter.spec.ts
+++ b/processor/test/services/converters/refund.converter.spec.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from '@jest/globals';
 import { mockGetPaymentResult } from '../../utils/mock-payment-data';
 import { config } from '../../../src/config/config';
 import { RefundPaymentConverter } from '../../../src/services/converters/refund-payment.converter';
+import { Payment } from '@commercetools/connect-payments-sdk';
 
 describe('refund.converter', () => {
   const converter = new RefundPaymentConverter();
@@ -49,5 +50,142 @@ describe('refund.converter', () => {
         value: mockGetPaymentResult.amountPlanned.centAmount,
       },
     });
+  });
+
+  test('convert refund for a PayPal payment with transactionId', async () => {
+    // Arrange
+    const payment = {
+      id: '123456',
+      version: 1,
+      amountPlanned: {
+        type: 'centPrecision',
+        currencyCode: 'GBP',
+        centAmount: 120000,
+        fractionDigits: 2,
+      },
+      interfaceId: '92C12661DS923781G',
+      paymentMethodInfo: {
+        method: 'paypal',
+      },
+      transactions: [
+        {
+          id: 'dummy-transaction-id',
+          type: 'Charge',
+          interactionId: 'some-psp-reference',
+          amount: {
+            type: 'centPrecision',
+            currencyCode: 'GBP',
+            centAmount: 120000,
+            fractionDigits: 2,
+          },
+          state: 'Success',
+        },
+      ],
+    } as Payment;
+    const data = {
+      amount: mockGetPaymentResult.amountPlanned,
+      payment,
+      transactionId: payment.transactions[0].id,
+    };
+
+    // Act
+    const result = converter.convertRequest(data);
+
+    // Assert
+    expect(result).toEqual({
+      merchantAccount: config.adyenMerchantAccount,
+      reference: mockGetPaymentResult.id,
+      amount: {
+        currency: mockGetPaymentResult.amountPlanned.currencyCode,
+        value: mockGetPaymentResult.amountPlanned.centAmount,
+      },
+      capturePspReference: payment.transactions[0].interactionId,
+    });
+  });
+
+  test('convert refund for a PayPal payment throws an error when transactionId provided does not exist', async () => {
+    // Arrange
+    const payment = {
+      id: '123456',
+      version: 1,
+      amountPlanned: {
+        type: 'centPrecision',
+        currencyCode: 'GBP',
+        centAmount: 120000,
+        fractionDigits: 2,
+      },
+      interfaceId: '92C12661DS923781G',
+      paymentMethodInfo: {
+        method: 'paypal',
+      },
+      transactions: [
+        {
+          id: 'dummy-transaction-id',
+          type: 'Charge',
+          interactionId: 'some-psp-reference',
+          amount: {
+            type: 'centPrecision',
+            currencyCode: 'GBP',
+            centAmount: 120000,
+            fractionDigits: 2,
+          },
+          state: 'Success',
+        },
+      ],
+    } as Payment;
+
+    const data = {
+      amount: mockGetPaymentResult.amountPlanned,
+      payment,
+      transactionId: 'non-existent-transaction-id',
+    };
+
+    // Act & Assert
+    expect(() => {
+      converter.convertRequest(data);
+    }).toThrow(`Transaction with ID 'non-existent-transaction-id' does not exist`);
+  });
+
+  test('convert refund for a PayPal payment throws an error when transactionId provided is not of type Charge', async () => {
+    // Arrange
+    const payment = {
+      id: '123456',
+      version: 1,
+      amountPlanned: {
+        type: 'centPrecision',
+        currencyCode: 'GBP',
+        centAmount: 120000,
+        fractionDigits: 2,
+      },
+      interfaceId: '92C12661DS923781G',
+      paymentMethodInfo: {
+        method: 'paypal',
+      },
+      transactions: [
+        {
+          id: 'dummy-transaction-id',
+          type: 'CancelAuthorization',
+          interactionId: 'some-psp-reference',
+          amount: {
+            type: 'centPrecision',
+            currencyCode: 'GBP',
+            centAmount: 120000,
+            fractionDigits: 2,
+          },
+          state: 'Initial',
+        },
+      ],
+    } as Payment;
+
+    const data = {
+      amount: mockGetPaymentResult.amountPlanned,
+      payment,
+      transactionId: payment.transactions[0].id,
+    };
+
+    // Act & Assert
+    expect(() => {
+      converter.convertRequest(data);
+    }).toThrow(`Transaction with ID '${payment.transactions[0].id}' must be of type 'Charge'`);
   });
 });


### PR DESCRIPTION
Thule created a support ticket requesting the ability to link a refund to the capture reference, as this is a mandatory attribute for PayPal payments processed through Adyen.

To support this, the refundPayment action of the Payment Intents API has been extended to include a new transactionId attribute. This attribute will contain the ID of a CoCo payment transaction. From this transaction, the connector extracts the capture reference from the interactionId field and sends it to the PSP.

Associated ticket: https://commercetools.atlassian.net/browse/SCC-3413