### PR TITLE
feat(saved-payment-method): add support for showing, storing, paying and deleting saved payment methods

### DIFF
--- a/connect.yaml
+++ b/connect.yaml
@@ -82,6 +82,9 @@ deployAs:
         - key: ADYEN_NOTIFICATION_HMAC_KEY
           description: Adyen HMAC key (Please use the dummy placeholder value during the installation process. Once the webhook configuration in Adyen is complete and HMAC known, replace this placeholder with the actual value and redeploy.)
           required: true
+        - key: ADYEN_NOTIFICATION_HMAC_TOKENIZATION_WEBHOOKS_KEY
+          description: Adyen HMAC tokenization webhooks key. This will be used if provided, otherwise the ADYEN_NOTIFICATION_HMAC_KEY will be used. (Please use the dummy placeholder value during the installation process. Once the webhook configuration in Adyen is complete and HMAC known, replace this placeholder with the actual value and redeploy.)
+          required: false
         - key: ADYEN_APPLEPAY_OWN_CERTIFICATE
           description: Apple Pay own certificate in base 64 format
           required: false

--- a/connect.yaml
+++ b/connect.yaml
@@ -62,6 +62,16 @@ deployAs:
         - key: ADYEN_PAYMENT_COMPONENTS_CONFIG
           description: 'Adyen payment components configuration in JSON String format. For example: {"paypal":{"blockPayPalVenmoButton":false}}. Please refer to the Adyen documentation for more details.'
           required: false
+        - key: ADYEN_SAVED_PAYMENT_METHOD_ENABLED
+          description: If set to "true" then the saved payment methods feature is enabled. Default value is "false".
+          required: false
+        - key: ADYEN_SAVED_PAYMENT_METHOD_PAYMENT_INTERFACE
+          description: The payment method payment interface value used in the commerceotools payment methods. Default value is "adyen".
+          required: false
+        - key: ADYEN_SAVED_PAYMENT_METHOD_INTERFACE_ACCOUNT
+          description: The payment method interface account value used in the commerceotools payment methods.
+          required: false
+
       securedConfiguration:
         - key: CTP_CLIENT_SECRET
           description: commercetools client secret

--- a/enabler/index.html
+++ b/enabler/index.html
@@ -86,6 +86,8 @@
         </div>
       </section>
 
+      <!-- SCC-3447: add test functionality for showing/rendering the saved pm (for both web-component and dropins) -->
+
       <div class="album py-5 bg-light">
         <div class="container">
           <script type="module">

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -34,11 +34,14 @@ export class DropinEmbeddedBuilder implements PaymentDropinBuilder {
   public dropinHasSubmit = false;
   private paymentComponentsConfigOverride: Record<string, any>;
   private adyenCheckout: ICore;
+  private isSavedPaymentMethodsEnabled: boolean;
 
   constructor(baseOptions: BaseOptions) {
     this.adyenCheckout = baseOptions.adyenCheckout;
     this.paymentComponentsConfigOverride =
       baseOptions.paymentComponentsConfigOverride;
+    this.isSavedPaymentMethodsEnabled =
+      baseOptions.isSavedPaymentMethodsEnabled;
   }
 
   build(config: DropinOptions): DropinComponent {
@@ -46,6 +49,7 @@ export class DropinEmbeddedBuilder implements PaymentDropinBuilder {
       adyenCheckout: this.adyenCheckout,
       dropinOptions: config,
       dropinConfigOverride: this.resolveDropinComponentConfigOverride(),
+      isSavedPaymentMethodsEnabled: this.isSavedPaymentMethodsEnabled,
     });
 
     dropin.init();
@@ -62,15 +66,18 @@ export class DropinComponents implements DropinComponent {
   private adyenCheckout: ICore;
   private dropinOptions: DropinOptions;
   private dropinConfigOverride: Record<string, any>;
+  private isSavedPaymentMethodsEnabled: boolean;
 
   constructor(opts: {
     adyenCheckout: ICore;
     dropinOptions: DropinOptions;
     dropinConfigOverride: Record<string, any>;
+    isSavedPaymentMethodsEnabled: boolean;
   }) {
     this.dropinOptions = opts.dropinOptions;
     this.adyenCheckout = opts.adyenCheckout;
     this.dropinConfigOverride = opts.dropinConfigOverride;
+    this.isSavedPaymentMethodsEnabled = opts.isSavedPaymentMethodsEnabled;
 
     this.overrideOnSubmit();
   }
@@ -80,8 +87,13 @@ export class DropinComponents implements DropinComponent {
       showPayButton: true,
       showRadioButton: false,
       openFirstStoredPaymentMethod: false,
-      showStoredPaymentMethods: false,
+      showStoredPaymentMethods: this.isSavedPaymentMethodsEnabled,
+      showRemovePaymentMethodButton: this.isSavedPaymentMethodsEnabled,
       isDropin: true,
+      onDisableStoredPaymentMethod: (resolve) => {
+        // TODO: SCC-3447: implement disable (i.e. remove button functionality) for drop-in component
+        return resolve();
+      },
       onReady: () => {
         if (this.dropinOptions.onDropinReady) {
           this.dropinOptions
@@ -141,7 +153,6 @@ export class DropinComponents implements DropinComponent {
           ],
           // Configuration that can not be overridden
         },
-
         card: {
           hasHolderName: true,
           holderNameRequired: true,
@@ -150,6 +161,7 @@ export class DropinComponents implements DropinComponent {
             getPaymentMethodType(PaymentMethod.card)
           ],
           // Configuration that can not be overridden
+          enableStoreDetails: this.isSavedPaymentMethodsEnabled,
         },
         googlepay: {
           buttonType: "pay",

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -91,7 +91,7 @@ export class DropinComponents implements DropinComponent {
       showRemovePaymentMethodButton: this.isSavedPaymentMethodsEnabled,
       isDropin: true,
       onDisableStoredPaymentMethod: (resolve) => {
-        // TODO: SCC-3447: implement disable (i.e. remove button functionality) for drop-in component
+        // TODO: SCC-3447: implement disable (i.e. remove button functionality) for drop-in component. It should call a HTTP DELETE /stored-payment-methods/{uuid} endpoint. Which should remove it from Adyen and COCO
         return resolve();
       },
       onReady: () => {

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -65,6 +65,7 @@ export type BaseOptions = {
     usesOwnCertificate: boolean;
   };
   paymentComponentsConfigOverride?: Record<string, any>;
+  isSavedPaymentMethodsEnabled: boolean;
 };
 
 export class AdyenPaymentEnabler implements PaymentEnabler {
@@ -267,6 +268,7 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
           ...(configJson.paymentComponentsConfig && {
             paymentComponentsConfigOverride: configJson.paymentComponentsConfig,
           }),
+          isSavedPaymentMethodsEnabled: configJson.isSavedPaymentMethodsEnabled,
         },
       };
     }

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -162,7 +162,6 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
               shopperLocale: adyenLocale,
               channel: "Web",
               paymentReference,
-              // cocoSavedPaymentMethodId: "5cb63117-e92c-4891-94dc-6349d1600649",
             };
 
             const response = await fetch(options.processorUrl + "/payments", {

--- a/enabler/src/payment-enabler/adyen-payment-enabler.ts
+++ b/enabler/src/payment-enabler/adyen-payment-enabler.ts
@@ -162,7 +162,9 @@ export class AdyenPaymentEnabler implements PaymentEnabler {
               shopperLocale: adyenLocale,
               channel: "Web",
               paymentReference,
+              // cocoSavedPaymentMethodId: "5cb63117-e92c-4891-94dc-6349d1600649",
             };
+
             const response = await fetch(options.processorUrl + "/payments", {
               method: "POST",
               headers: {

--- a/processor/src/config/config.ts
+++ b/processor/src/config/config.ts
@@ -18,6 +18,8 @@ export const config = {
   adyenClientKey: process.env.ADYEN_CLIENT_KEY || 'adyenClientKey',
   adyenApiKey: process.env.ADYEN_API_KEY || 'adyenApiKey',
   adyenHMACKey: process.env.ADYEN_NOTIFICATION_HMAC_KEY || 'adyenHMACKey',
+  adyenHMACTokenizationWebHooksKey:
+    process.env.ADYEN_NOTIFICATION_HMAC_TOKENIZATION_WEBHOOKS_KEY || 'adyenHMACTokenizationWebHooksKey',
   adyenLiveUrlPrefix: process.env.ADYEN_LIVE_URL_PREFIX || '',
   adyenMerchantAccount: process.env.ADYEN_MERCHANT_ACCOUNT || 'adyenMerchantAccount',
   adyenApplePayOwnCerticate: process.env.ADYEN_APPLEPAY_OWN_CERTIFICATE

--- a/processor/src/config/config.ts
+++ b/processor/src/config/config.ts
@@ -29,7 +29,11 @@ export const config = {
   adyenShopperStatement: process.env.ADYEN_SHOPPER_STATEMENT || '',
   adyenPaymentComponentsConfig: process.env.ADYEN_PAYMENT_COMPONENTS_CONFIG || '',
   merchantReturnUrl: process.env.MERCHANT_RETURN_URL || '',
+  adyenSavedPaymentMethodsEnabled: process.env.ADYEN_SAVED_PAYMENT_METHOD_ENABLED || 'false',
+  adyenSavedPaymentMethodsPaymentInterface: process.env.ADYEN_SAVED_PAYMENT_METHOD_PAYMENT_INTERFACE || 'adyen',
+  adyenSavedPaymentMethodsInterfaceAccount: process.env.ADYEN_SAVED_PAYMENT_METHOD_INTERFACE_ACCOUNT || undefined,
 };
+
 export const getConfig = () => {
   return config;
 };

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -37,7 +37,6 @@ export const paymentMethodConfig: PaymentMethodConfig = {
   },
 };
 
-// TODO: SCC-3447: do we need to pass this info to the enabler in order to allow/disallow certain stored web-components to be loaded?
 export type SupportedSavedPaymentMethodTypes = {
   [key: string]: {
     oneOffPayments: boolean;

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -36,3 +36,19 @@ export const paymentMethodConfig: PaymentMethodConfig = {
     supportSeparateCapture: false,
   },
 };
+
+// TODO: SCC-3447: do we need to pass this info to the enabler in order to allow/disallow certain stored web-components to be loaded?
+export type SupportedSavedPaymentMethodTypes = {
+  [key: string]: {
+    oneOffPayments: boolean;
+  };
+};
+
+/**
+ * Represents which payment methods are supported for tokenization. The key represents the type value of the payment method as defined by Adyen.
+ */
+export const supportedSavedPaymentMethodTypes: SupportedSavedPaymentMethodTypes = {
+  scheme: {
+    oneOffPayments: true,
+  },
+};

--- a/processor/src/config/saved-payment-method.config.ts
+++ b/processor/src/config/saved-payment-method.config.ts
@@ -1,0 +1,27 @@
+import { getConfig } from './config';
+
+export type SavedPaymentMethodConfig = {
+  enabled: boolean; // indicates if tokenization feature is enabled
+  config: {
+    paymentInterface: string; // paymentInterface to set
+    interfaceAccount?: string; // optional interfaceAccount to set
+  };
+};
+
+let savedPaymentConfigValidated: SavedPaymentMethodConfig;
+
+export const getSavedPaymentsConfig = (): SavedPaymentMethodConfig => {
+  if (savedPaymentConfigValidated) {
+    return savedPaymentConfigValidated;
+  }
+
+  savedPaymentConfigValidated = {
+    enabled: getConfig().adyenSavedPaymentMethodsEnabled === 'true',
+    config: {
+      paymentInterface: getConfig().adyenSavedPaymentMethodsPaymentInterface,
+      interfaceAccount: getConfig().adyenSavedPaymentMethodsInterfaceAccount,
+    },
+  };
+
+  return savedPaymentConfigValidated;
+};

--- a/processor/src/dtos/adyen-payment.dto.ts
+++ b/processor/src/dtos/adyen-payment.dto.ts
@@ -7,6 +7,7 @@ import { PaymentMethodsResponse } from '@adyen/api-library/lib/src/typings/check
 import { PaymentRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRequest';
 import { PaymentResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentResponse';
 import { Notification } from '@adyen/api-library/lib/src/typings/notification/notification';
+import { GenericWebhook } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationWebhooksHandler';
 
 export type PaymentMethodsRequestDTO = Omit<PaymentMethodsRequest, 'amount' | 'merchantAccount' | 'countryCode'>;
 export type PaymentMethodsResponseDTO = PaymentMethodsResponse;
@@ -42,8 +43,6 @@ export type CreatePaymentRequestDTO = Omit<
   | 'recurringProcessingModel'
 > & {
   paymentReference?: string;
-  storePaymentDetails?: boolean;
-  cocoSavedPaymentMethodId?: string;
 };
 
 export type CreatePaymentResponseDTO = Pick<
@@ -67,6 +66,8 @@ export type ConfirmPaymentResponseDTO = Pick<
 };
 
 export type NotificationRequestDTO = Notification;
+
+export type NotificationTokenizationDTO = GenericWebhook;
 
 export type CreateApplePaySessionRequestDTO = {
   validationUrl: string;

--- a/processor/src/dtos/adyen-payment.dto.ts
+++ b/processor/src/dtos/adyen-payment.dto.ts
@@ -42,6 +42,8 @@ export type CreatePaymentRequestDTO = Omit<
   | 'recurringProcessingModel'
 > & {
   paymentReference?: string;
+  storePaymentDetails?: boolean;
+  cocoSavedPaymentMethodId?: string;
 };
 
 export type CreatePaymentResponseDTO = Pick<

--- a/processor/src/dtos/operations/config.dto.ts
+++ b/processor/src/dtos/operations/config.dto.ts
@@ -9,6 +9,7 @@ export const ConfigResponseSchema = Type.Object({
     }),
   ),
   paymentComponentsConfig: Type.Optional(Type.Any()),
+  isSavedPaymentMethodsEnabled: Type.Boolean(),
 });
 
 export type ConfigResponseSchemaDTO = Static<typeof ConfigResponseSchema>;

--- a/processor/src/dtos/saved-payment-methods.dto.ts
+++ b/processor/src/dtos/saved-payment-methods.dto.ts
@@ -1,0 +1,24 @@
+import { Static, Type } from '@sinclair/typebox';
+
+export const StoredPaymentMethodSchema = Type.Object({
+  id: Type.String(),
+  type: Type.String(),
+  token: Type.String(),
+  isDefault: Type.Boolean(),
+  createdAt: Type.String({ format: 'date-time' }),
+  displayOptions: Type.Object({
+    name: Type.String(),
+    endDigits: Type.Optional(Type.String()),
+    brand: Type.Optional(Type.String()),
+    expiryMonth: Type.Optional(Type.String()),
+    expiryYear: Type.Optional(Type.String()),
+    logoUrl: Type.Optional(Type.String()),
+  }),
+});
+
+export const StoredPaymentMethodsResponseSchema = Type.Object({
+  storedPaymentMethods: Type.Array(StoredPaymentMethodSchema),
+});
+
+export type StoredPaymentMethod = Static<typeof StoredPaymentMethodSchema>;
+export type StoredPaymentMethodsResponse = Static<typeof StoredPaymentMethodsResponseSchema>;

--- a/processor/src/libs/fastify/hooks/hmac-auth.hook.ts
+++ b/processor/src/libs/fastify/hooks/hmac-auth.hook.ts
@@ -4,6 +4,9 @@ import { FastifyRequest } from 'fastify';
 import { ErrorAuthErrorResponse } from '@commercetools/connect-payments-sdk';
 import { NotificationRequestDTO } from '../../../dtos/adyen-payment.dto';
 
+/**
+ * @see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures/?programming_language=js
+ */
 export class HmacAuthHook {
   public authenticate() {
     return async (request: FastifyRequest) => {

--- a/processor/src/libs/fastify/hooks/hmac-header-auth.hook.ts
+++ b/processor/src/libs/fastify/hooks/hmac-header-auth.hook.ts
@@ -1,0 +1,41 @@
+import HmacValidator from '@adyen/api-library/lib/src/utils/hmacValidator';
+import { config } from '../../../config/config';
+import { FastifyRequest } from 'fastify';
+import { ErrorAuthErrorResponse } from '@commercetools/connect-payments-sdk';
+
+export class HmacHeaderAuthHook {
+  public authenticate() {
+    return async (request: FastifyRequest) => {
+      const hmacSignatureHeaders = request.headers['hmacsignature'];
+
+      if (!hmacSignatureHeaders) {
+        throw new ErrorAuthErrorResponse('No hmac signature header found in the request');
+      }
+
+      let hmacSignature: string;
+
+      if (Array.isArray(hmacSignatureHeaders)) {
+        if (hmacSignatureHeaders.length !== 1) {
+          throw new ErrorAuthErrorResponse('Exactly one hmac signature needs to be provided');
+        }
+
+        hmacSignature = hmacSignatureHeaders[0];
+      } else {
+        hmacSignature = hmacSignatureHeaders;
+      }
+
+      const hmacKey = config.adyenHMACTokenizationWebHooksKey
+        ? config.adyenHMACTokenizationWebHooksKey
+        : config.adyenHMACKey;
+
+      const validator = new HmacValidator();
+
+      const reqBody = JSON.stringify(request.body);
+      const isValid = validator.validateHMACSignature(hmacKey, hmacSignature, reqBody);
+
+      if (!isValid) {
+        throw new ErrorAuthErrorResponse('HMAC is not valid');
+      }
+    };
+  }
+}

--- a/processor/src/libs/fastify/hooks/hmac-header-auth.hook.ts
+++ b/processor/src/libs/fastify/hooks/hmac-header-auth.hook.ts
@@ -3,6 +3,9 @@ import { config } from '../../../config/config';
 import { FastifyRequest } from 'fastify';
 import { ErrorAuthErrorResponse } from '@commercetools/connect-payments-sdk';
 
+/**
+ * @see https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures/#verify-hmac-in-header
+ */
 export class HmacHeaderAuthHook {
   public authenticate() {
     return async (request: FastifyRequest) => {

--- a/processor/src/routes/adyen-payment.route.ts
+++ b/processor/src/routes/adyen-payment.route.ts
@@ -13,6 +13,7 @@ import {
   CreatePaymentResponseDTO,
   CreateSessionRequestDTO,
   CreateSessionResponseDTO,
+  NotificationTokenizationDTO,
   NotificationRequestDTO,
   PaymentMethodsRequestDTO,
   PaymentMethodsResponseDTO,
@@ -20,12 +21,14 @@ import {
 import { AdyenPaymentService } from '../services/adyen-payment.service';
 import { HmacAuthHook } from '../libs/fastify/hooks/hmac-auth.hook';
 import { StoredPaymentMethodsResponseSchema } from '../dtos/saved-payment-methods.dto';
+import { HmacHeaderAuthHook } from '../libs/fastify/hooks/hmac-header-auth.hook';
 
 type PaymentRoutesOptions = {
   paymentService: AdyenPaymentService;
   sessionHeaderAuthHook: SessionHeaderAuthenticationHook;
   sessionQueryParamAuthHook: SessionQueryParamAuthenticationHook;
   hmacAuthHook: HmacAuthHook;
+  hmacHeaderAuthHook: HmacHeaderAuthHook;
 };
 
 export const adyenPaymentRoutes = async (
@@ -147,6 +150,20 @@ export const adyenPaymentRoutes = async (
     },
     async (request, reply) => {
       await opts.paymentService.processNotification({
+        data: request.body,
+      });
+
+      return reply.status(200).send('[accepted]');
+    },
+  );
+
+  fastify.post<{ Body: NotificationTokenizationDTO }>(
+    '/notifications/tokenization',
+    {
+      preHandler: [opts.hmacHeaderAuthHook.authenticate()],
+    },
+    async (request, reply) => {
+      await opts.paymentService.processNotificationTokenization({
         data: request.body,
       });
 

--- a/processor/src/routes/adyen-payment.route.ts
+++ b/processor/src/routes/adyen-payment.route.ts
@@ -19,6 +19,7 @@ import {
 } from '../dtos/adyen-payment.dto';
 import { AdyenPaymentService } from '../services/adyen-payment.service';
 import { HmacAuthHook } from '../libs/fastify/hooks/hmac-auth.hook';
+import { StoredPaymentMethodsResponseSchema } from '../dtos/saved-payment-methods.dto';
 
 type PaymentRoutesOptions = {
   paymentService: AdyenPaymentService;
@@ -150,6 +151,22 @@ export const adyenPaymentRoutes = async (
       });
 
       return reply.status(200).send('[accepted]');
+    },
+  );
+
+  fastify.get(
+    '/stored-payment-methods',
+    {
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
+      schema: {
+        response: {
+          200: StoredPaymentMethodsResponseSchema,
+        },
+      },
+    },
+    async (_, reply) => {
+      const res = await opts.paymentService.getSavedPaymentMethods();
+      reply.code(200).send(res);
     },
   );
 };

--- a/processor/src/server/app.ts
+++ b/processor/src/server/app.ts
@@ -1,4 +1,5 @@
 import { HmacAuthHook } from '../libs/fastify/hooks/hmac-auth.hook';
+import { HmacHeaderAuthHook } from '../libs/fastify/hooks/hmac-header-auth.hook';
 import { paymentSDK } from '../payment-sdk';
 import { AdyenPaymentService } from '../services/adyen-payment.service';
 
@@ -15,5 +16,6 @@ export const app = {
   },
   hooks: {
     hmacAuthHook: new HmacAuthHook(),
+    hmacHeaderAuthHook: new HmacHeaderAuthHook(),
   },
 };

--- a/processor/src/server/app.ts
+++ b/processor/src/server/app.ts
@@ -6,6 +6,7 @@ const paymentService = new AdyenPaymentService({
   ctCartService: paymentSDK.ctCartService,
   ctPaymentService: paymentSDK.ctPaymentService,
   ctOrderService: paymentSDK.ctOrderService,
+  ctPaymentMethodService: paymentSDK.ctPaymentMethodService,
 });
 
 export const app = {

--- a/processor/src/server/plugins/adyen-payment.plugin.ts
+++ b/processor/src/server/plugins/adyen-payment.plugin.ts
@@ -9,5 +9,6 @@ export default async function (server: FastifyInstance) {
     sessionHeaderAuthHook: paymentSDK.sessionHeaderAuthHookFn,
     sessionQueryParamAuthHook: paymentSDK.sessionQueryParamAuthHookFn,
     hmacAuthHook: app.hooks.hmacAuthHook,
+    hmacHeaderAuthHook: app.hooks.hmacHeaderAuthHook,
   });
 }

--- a/processor/src/server/server.ts
+++ b/processor/src/server/server.ts
@@ -33,6 +33,7 @@ export const setupFastify = async () => {
 
   // Enable CORS
   await server.register(cors, {
+    methods: ['GET', 'HEAD', 'POST', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Correlation-ID', 'X-Request-ID', 'X-Session-ID'],
     origin: '*',
   });

--- a/processor/src/services/abstract-payment.service.ts
+++ b/processor/src/services/abstract-payment.service.ts
@@ -1,6 +1,7 @@
 import {
   CommercetoolsCartService,
   CommercetoolsOrderService,
+  CommercetoolsPaymentMethodService,
   CommercetoolsPaymentService,
   ErrorInvalidOperation,
 } from '@commercetools/connect-payments-sdk';
@@ -17,20 +18,24 @@ import {
 import { PaymentIntentResponseSchemaDTO, PaymentModificationStatus } from '../dtos/operations/payment-intents.dto';
 import { SupportedPaymentComponentsSchemaDTO } from '../dtos/operations/payment-componets.dto';
 import { log } from '../libs/logger';
+import { StoredPaymentMethodsResponse } from '../dtos/saved-payment-methods.dto';
 
 export abstract class AbstractPaymentService {
   protected ctCartService: CommercetoolsCartService;
   protected ctPaymentService: CommercetoolsPaymentService;
   protected ctOrderService: CommercetoolsOrderService;
+  protected ctPaymentMethodService: CommercetoolsPaymentMethodService;
 
   constructor(
     ctCartService: CommercetoolsCartService,
     ctPaymentService: CommercetoolsPaymentService,
     ctOrderService: CommercetoolsOrderService,
+    ctPaymentMethodService: CommercetoolsPaymentMethodService,
   ) {
     this.ctCartService = ctCartService;
     this.ctPaymentService = ctPaymentService;
     this.ctOrderService = ctOrderService;
+    this.ctPaymentMethodService = ctPaymentMethodService;
   }
 
   /**
@@ -81,6 +86,11 @@ export abstract class AbstractPaymentService {
    * @returns Promise with outcome containing operation status and PSP reference
    */
   abstract reversePayment(request: ReversePaymentRequest): Promise<PaymentProviderModificationResponse>;
+
+  /**
+   * Get list of stored payment methods
+   */
+  abstract getSavedPaymentMethods(): Promise<StoredPaymentMethodsResponse>;
 
   public async modifyPayment(opts: ModifyPayment): Promise<PaymentIntentResponseSchemaDTO> {
     const ctPayment = await this.ctPaymentService.getPayment({

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -22,6 +22,7 @@ import {
   CreatePaymentResponseDTO,
   CreateSessionRequestDTO,
   CreateSessionResponseDTO,
+  NotificationTokenizationDTO,
   NotificationRequestDTO,
   PaymentMethodsRequestDTO,
   PaymentMethodsResponseDTO,
@@ -67,6 +68,7 @@ import { PaymentCancelResponse } from '@adyen/api-library/lib/src/typings/checko
 import { PaymentRefundResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentRefundResponse';
 import { getSavedPaymentsConfig } from '../config/saved-payment-method.config';
 import { StoredPaymentMethod, StoredPaymentMethodsResponse } from '../dtos/saved-payment-methods.dto';
+import { NotificationTokenizationConverter } from './converters/notification-recurring.converter';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJSON = require('../../package.json');
@@ -84,6 +86,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
   private createPaymentConverter: CreatePaymentConverter;
   private confirmPaymentConverter: ConfirmPaymentConverter;
   private notificationConverter: NotificationConverter;
+  private notificationTokenizationConverter: NotificationTokenizationConverter;
   private paymentComponentsConverter: PaymentComponentsConverter;
   private cancelPaymentConverter: CancelPaymentConverter;
   private capturePaymentConverter: CapturePaymentConverter;
@@ -97,6 +100,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
     this.createPaymentConverter = new CreatePaymentConverter(this.ctPaymentMethodService);
     this.confirmPaymentConverter = new ConfirmPaymentConverter();
     this.notificationConverter = new NotificationConverter(this.ctPaymentService);
+    this.notificationTokenizationConverter = new NotificationTokenizationConverter();
     this.paymentComponentsConverter = new PaymentComponentsConverter();
     this.cancelPaymentConverter = new CancelPaymentConverter();
     this.capturePaymentConverter = new CapturePaymentConverter(this.ctCartService, this.ctOrderService);
@@ -438,6 +442,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
       log.error('Error processing notification', { error: e });
       throw e;
     }
+  }
+
+  public async processNotificationTokenization(opts: { data: NotificationTokenizationDTO }): Promise<void> {
+    await this.notificationTokenizationConverter.convert(opts);
   }
 
   async capturePayment(request: CapturePaymentRequest): Promise<PaymentProviderModificationResponse> {

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -340,7 +340,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       this.isActionRequired(res),
     );
 
-    // TODO: SCC-3447: if the user payed with a spm, then the token (and the rest of the payment details --> this is already done) must be stored in the commercetools Payment entity.
+    // TODO: SCC-3447: (SCC-3449) if the user payed with a spm, then the token (and the rest of the payment details --> this is already done) must be stored in the commercetools Payment entity.
 
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
@@ -604,8 +604,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       interfaceAccount: getSavedPaymentsConfig().config.interfaceAccount,
     });
 
-    // TODO: SCC-3447: if the .env toggle is DISABLED then try and retrieve as much as possible from the Adyen API during runtime for the displayOptions
-    // TODO: SCC-3447: if the .env toggle is ENABLED then use that information to show the displayOptions
+    // TODO: SCC-3447: (SCC-3449) if the .env toggle is DISABLED then try and retrieve as much as possible from the Adyen API during runtime for the displayOptions
+    // TODO: SCC-3447: (SCC-3449) if the .env toggle is ENABLED then use that information to show the displayOptions
     const resList = savedPaymentMethods.results.map((spm) => {
       const res: StoredPaymentMethod = {
         id: spm.id,

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -447,10 +447,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
     log.info('Processing notification tokenization', { notification: JSON.stringify(opts.data) });
 
     try {
-      const result = await this.notificationTokenizationConverter.convert(opts);
+      const actions = await this.notificationTokenizationConverter.convert(opts);
 
-      if (result.draft) {
-        const newlyCreatedPaymentMethod = await this.ctPaymentMethodService.save(result.draft);
+      if (actions.draft) {
+        const newlyCreatedPaymentMethod = await this.ctPaymentMethodService.save(actions.draft);
 
         log.info('Created new payment method used for tokenization', {
           notification: JSON.stringify(opts.data),
@@ -460,7 +460,6 @@ export class AdyenPaymentService extends AbstractPaymentService {
             paymentInterface: newlyCreatedPaymentMethod.paymentInterface,
             interfaceAccount: newlyCreatedPaymentMethod.interfaceAccount,
             method: newlyCreatedPaymentMethod.method,
-            token: newlyCreatedPaymentMethod.token,
           },
         });
       }

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -336,6 +336,9 @@ export class AdyenPaymentService extends AbstractPaymentService {
       this.isActionRequired(res),
     );
 
+    // TODO: SCC-3447: if the user payed with a spm, then the token and the rest of the payment details must be stored in the commercetools Payment entity.
+    // (copied over via the payment update action "setMethodInfo") Does that happen here or in the webhook? (take into account timing between the /payments request vs receiving the notification)
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
       pspReference: res.pspReference,

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -655,6 +655,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       tokenValue: id,
     });
 
+    // TODO: SCC-3447: what type of error processing do we want here?
     const result = await Promise.allSettled([
       this.ctPaymentMethodService.delete({
         customerId: customerId,

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -47,7 +47,7 @@ export class CreatePaymentConverter {
     // const cocoSavedPaymentMethod = undefined;
 
     // TODO: SCC-3447: this boolean value is given as a new parameter to this function by the SPA/enabler if the customer wants to save the pm. Could this differ between web-component and drop-in?
-    const shouldUseOrStorePaymentMethod = true; // opts.data.storePaymentMethod ? true : false; // for testing right now use the value from the adyen build-in component. (web-component or drop-in)
+    const shouldUseOrStorePaymentMethod = opts.data.storePaymentMethod ? true : false; // for testing right now use the value from the adyen build-in component. (web-component or drop-in)
 
     const savedPaymentMethodData = await this.populateSavedPaymentMethodData(
       opts.data,

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -102,6 +102,8 @@ export class CreatePaymentConverter {
 
     const payWithExistingToken = Object.keys(data.paymentMethod).includes('storedPaymentMethodId');
 
+    // TODO: SCC-3447: if payWithExistingToken === true make sure to explicitly validate that the given storedPaymentMethodId belongs to the customerId on the cart via fetching the PM from CoCO and checking if the token.value matches with the storedPaymentMethodId
+
     // User does not want to store token for the first time nor pay with existing one
     if (!data.storePaymentMethod && !payWithExistingToken) {
       return;

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -1,7 +1,14 @@
 import { PaymentRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRequest';
-import { config } from '../../config/config';
 import { ThreeDSRequestData } from '@adyen/api-library/lib/src/typings/checkout/threeDSRequestData';
-import { Cart, CurrencyConverters, Payment } from '@commercetools/connect-payments-sdk';
+
+import { config } from '../../config/config';
+import {
+  Cart,
+  CurrencyConverters,
+  Payment,
+  CommercetoolsPaymentMethodService,
+  ErrorRequiredField,
+} from '@commercetools/connect-payments-sdk';
 import {
   buildReturnUrl,
   getShopperStatement,
@@ -14,14 +21,41 @@ import { getFutureOrderNumberFromContext } from '../../libs/fastify/context/cont
 import { paymentSDK } from '../../payment-sdk';
 import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
 import { randomUUID } from 'node:crypto';
+import { supportedSavedPaymentMethodTypes } from '../../config/payment-method.config';
+import { getSavedPaymentsConfig } from '../../config/saved-payment-method.config';
 
 export class CreatePaymentConverter {
-  public convertRequest(opts: { data: CreatePaymentRequestDTO; cart: Cart; payment: Payment }): PaymentRequest {
+  private ctPaymentMethodService: CommercetoolsPaymentMethodService;
+
+  constructor(ctPaymentMethodService: CommercetoolsPaymentMethodService) {
+    this.ctPaymentMethodService = ctPaymentMethodService;
+  }
+
+  public async convertRequest(opts: {
+    data: CreatePaymentRequestDTO;
+    cart: Cart;
+    payment: Payment;
+  }): Promise<PaymentRequest> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { paymentReference: _, ...requestData } = opts.data;
     const futureOrderNumber = getFutureOrderNumberFromContext();
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();
+
+    // TODO: SCC-3447: this optional string value is given as a new parameter to this function by the SPA/enabler. Change this around. (undefined means no existing payment method will be used). Could this differ between web-component and drop-in?
+    const cocoSavedPaymentMethod = '5cb63117-e92c-4891-94dc-6349d1600649';
+    // const cocoSavedPaymentMethod = undefined;
+
+    // TODO: SCC-3447: this boolean value is given as a new parameter to this function by the SPA/enabler if the customer wants to save the pm. Could this differ between web-component and drop-in?
+    const shouldUseOrStorePaymentMethod = true; // opts.data.storePaymentMethod ? true : false; // for testing right now use the value from the adyen build-in component. (web-component or drop-in)
+
+    const savedPaymentMethodData = await this.populateSavedPaymentMethodData(
+      opts.data,
+      opts.cart,
+      shouldUseOrStorePaymentMethod,
+      cocoSavedPaymentMethod,
+    );
+
     return {
       ...requestData,
       amount: {
@@ -47,6 +81,101 @@ export class CreatePaymentConverter {
       ...this.populateAddionalPaymentMethodData(opts.data, opts.cart),
       applicationInfo: populateApplicationInfo(),
       ...(shopperStatement && { shopperStatement }),
+      ...savedPaymentMethodData,
+    };
+  }
+
+  private async populateSavedPaymentMethodData(
+    data: CreatePaymentRequestDTO,
+    cart: Cart,
+    shouldUseOrStorePaymentMethod: boolean,
+    cocoPaymentMethodId?: string,
+  ) {
+    if (!getSavedPaymentsConfig().enabled) {
+      return;
+    }
+
+    const paymentMethodType = data.paymentMethod.type;
+    if (
+      typeof paymentMethodType !== 'string' ||
+      !Object.keys(supportedSavedPaymentMethodTypes).includes(paymentMethodType)
+    ) {
+      return;
+    }
+
+    if (!shouldUseOrStorePaymentMethod) {
+      // Customer does not want to save payment method
+      return;
+    }
+
+    const customerReference = cart.customerId;
+
+    if (!customerReference) {
+      throw new ErrorRequiredField('customerId', {
+        privateMessage: 'The customerId is not set on the cart yet the customer wants to tokenize the payment',
+        privateFields: {
+          cart: {
+            id: cart.id,
+            typeId: 'cart',
+          },
+        },
+      });
+    }
+
+    // Customer wants to pay with an already saved payment method
+    if (cocoPaymentMethodId) {
+      const paymentMethodFromCoCo = await this.ctPaymentMethodService.get({
+        customerId: customerReference,
+        id: cocoPaymentMethodId,
+        paymentInterface: getSavedPaymentsConfig().config.paymentInterface,
+        interfaceAccount: getSavedPaymentsConfig().config.interfaceAccount,
+      });
+
+      const token = paymentMethodFromCoCo.token;
+
+      if (!token) {
+        throw new ErrorRequiredField('token', {
+          privateMessage:
+            'The token attribute is not set on the CT payment method yet the user wants to pay with the payment method',
+          privateFields: {
+            cart: {
+              id: cart.id,
+              typeId: 'cart',
+            },
+            paymentMethod: {
+              id: paymentMethodFromCoCo.id,
+              typeId: 'payment-method',
+            },
+            customer: {
+              id: customerReference,
+              typeId: 'customer',
+            },
+          },
+        });
+      }
+
+      return {
+        recurringProcessingModel: PaymentRequest.RecurringProcessingModelEnum.CardOnFile,
+        shopperInteraction: PaymentRequest.ShopperInteractionEnum.ContAuth,
+        shopperReference: customerReference,
+        paymentMethod: {
+          // TODO: SCC-3447: all explicit and implicit data that is required should be added here. The Adyen web-component and drop-in provide this in the incoming request but the token is retrieved from Coco saved pm. Do we need to combine anything?
+          ...data.paymentMethod,
+          storedPaymentMethodId: token.value,
+        },
+      };
+    }
+
+    // Customer wants to store the payment method
+    return {
+      recurringProcessingModel: PaymentRequest.RecurringProcessingModelEnum.CardOnFile,
+      shopperInteraction: PaymentRequest.ShopperInteractionEnum.Ecommerce,
+      shopperReference: customerReference,
+      storePaymentMethod: true,
+      paymentMethod: {
+        // TODO: SCC-3447: all explicit and implicit data that is required should be added here. The Adyen web-component and drop-in provide this in the incoming request. Is this always the case?
+        ...data.paymentMethod,
+      },
     };
   }
 

--- a/processor/src/services/converters/create-session.converter.ts
+++ b/processor/src/services/converters/create-session.converter.ts
@@ -14,6 +14,7 @@ import { getFutureOrderNumberFromContext } from '../../libs/fastify/context/cont
 import { paymentSDK } from '../../payment-sdk';
 import { CURRENCIES_FROM_ADYEN_TO_ISO_MAPPING, CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
 import { CreateCheckoutSessionResponse } from '@adyen/api-library/lib/src/typings/checkout/createCheckoutSessionResponse';
+import { getSavedPaymentsConfig } from '../../config/saved-payment-method.config';
 
 export class CreateSessionConverter {
   public convertRequest(opts: {
@@ -25,6 +26,7 @@ export class CreateSessionConverter {
     const futureOrderNumber = getFutureOrderNumberFromContext();
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();
+
     return {
       ...opts.data,
       amount: {
@@ -52,6 +54,13 @@ export class CreateSessionConverter {
       ...(futureOrderNumber && { merchantOrderReference: futureOrderNumber }),
       applicationInfo: populateApplicationInfo(),
       ...(shopperStatement && { shopperStatement }),
+      ...(getSavedPaymentsConfig().enabled && {
+        shopperReference: opts.cart.customerId,
+        recurringProcessingModel: CreateCheckoutSessionRequest.RecurringProcessingModelEnum.CardOnFile,
+        shopperInteraction: CreateCheckoutSessionRequest.ShopperInteractionEnum.Ecommerce,
+        storePaymentMethodMode: CreateCheckoutSessionRequest.StorePaymentMethodModeEnum.AskForConsent,
+        storePaymentMethod: true,
+      }),
     };
   }
 

--- a/processor/src/services/converters/notification-recurring.converter.ts
+++ b/processor/src/services/converters/notification-recurring.converter.ts
@@ -1,0 +1,16 @@
+// import {
+//   TokenizationWebhooksHandler,
+//   GenericWebhook,
+// } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationWebhooksHandler';
+// import { TokenizationCreatedDetailsNotificationRequest } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationCreatedDetailsNotificationRequest';
+// import { TokenizationNotificationResponse } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/models';
+import { NotificationTokenizationDTO } from '../../dtos/adyen-payment.dto';
+
+// TODO: SCC-3447: add support for the recurring.token.created event. This is part of a new webhook called "Recurring tokens life cycle events". Which is different from the standard one.
+// TODO: SCC-3447: The token and the rest of the payment details must be stored in the commercetools Payment entity. This must be copied over from the CoCo payment-method using the update action "setMethodInfo"
+// TODO: SCC-3447: during the handeling of the recurring.token.created event retrieve the displayable information and store it as a custom type. Specifically: name, endDigits, brand, expireMonth, expireYear and logoUrl
+
+// TODO: SCC-3447: implement NotificationRecurringConverter
+export class NotificationTokenizationConverter {
+  public async convert(opts: { data: NotificationTokenizationDTO }): Promise<void> {}
+}

--- a/processor/src/services/converters/notification-recurring.converter.ts
+++ b/processor/src/services/converters/notification-recurring.converter.ts
@@ -14,7 +14,7 @@ export class NotificationTokenizationConverter {
   public async convert(opts: {
     data: NotificationTokenizationDTO;
   }): Promise<NotificationTokenizationConverterResponse> {
-    let response: NotificationTokenizationConverterResponse = {};
+    const response: NotificationTokenizationConverterResponse = {};
 
     if (opts.data.type === TokenizationCreatedDetailsNotificationRequest.TypeEnum.RecurringTokenCreated) {
       response.draft = await this.processRecurringTokenCreated(opts.data);

--- a/processor/src/services/converters/notification-recurring.converter.ts
+++ b/processor/src/services/converters/notification-recurring.converter.ts
@@ -1,16 +1,46 @@
-// import {
-//   TokenizationWebhooksHandler,
-//   GenericWebhook,
-// } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationWebhooksHandler';
-// import { TokenizationCreatedDetailsNotificationRequest } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationCreatedDetailsNotificationRequest';
-// import { TokenizationNotificationResponse } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/models';
+import { TokenizationCreatedDetailsNotificationRequest } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationCreatedDetailsNotificationRequest';
+
+import { PaymentMethodDraft } from '@commercetools/connect-payments-sdk';
+
 import { NotificationTokenizationDTO } from '../../dtos/adyen-payment.dto';
+import { UnsupportedNotificationError } from '../../errors/adyen-api.error';
+import { getSavedPaymentsConfig } from '../../config/saved-payment-method.config';
 
-// TODO: SCC-3447: add support for the recurring.token.created event. This is part of a new webhook called "Recurring tokens life cycle events". Which is different from the standard one.
-// TODO: SCC-3447: The token and the rest of the payment details must be stored in the commercetools Payment entity. This must be copied over from the CoCo payment-method using the update action "setMethodInfo"
-// TODO: SCC-3447: during the handeling of the recurring.token.created event retrieve the displayable information and store it as a custom type. Specifically: name, endDigits, brand, expireMonth, expireYear and logoUrl
+export type NotificationTokenizationConverterResponse = {
+  draft?: PaymentMethodDraft;
+};
 
-// TODO: SCC-3447: implement NotificationRecurringConverter
 export class NotificationTokenizationConverter {
-  public async convert(opts: { data: NotificationTokenizationDTO }): Promise<void> {}
+  public async convert(opts: {
+    data: NotificationTokenizationDTO;
+  }): Promise<NotificationTokenizationConverterResponse> {
+    let response: NotificationTokenizationConverterResponse = {};
+
+    if (opts.data.type === TokenizationCreatedDetailsNotificationRequest.TypeEnum.RecurringTokenCreated) {
+      response.draft = await this.processRecurringTokenCreated(opts.data);
+    } else {
+      throw new UnsupportedNotificationError({ notificationEvent: opts.data.type });
+    }
+
+    return response;
+  }
+
+  private async processRecurringTokenCreated(
+    data: TokenizationCreatedDetailsNotificationRequest,
+  ): Promise<PaymentMethodDraft> {
+    return {
+      customer: {
+        id: data.data.shopperReference,
+        typeId: 'customer',
+      },
+      paymentInterface: getSavedPaymentsConfig().config.paymentInterface,
+      interfaceAccount: getSavedPaymentsConfig().config.interfaceAccount,
+      method: data.data.type,
+      default: false,
+      paymentMethodStatus: 'Active',
+      token: {
+        value: data.data.storedPaymentMethodId,
+      },
+    };
+  }
 }

--- a/processor/src/services/converters/notification-recurring.converter.ts
+++ b/processor/src/services/converters/notification-recurring.converter.ts
@@ -1,13 +1,13 @@
 import { TokenizationCreatedDetailsNotificationRequest } from '@adyen/api-library/lib/src/typings/tokenizationWebhooks/tokenizationCreatedDetailsNotificationRequest';
 
-import { PaymentMethodDraft } from '@commercetools/connect-payments-sdk';
+import { CommercetoolsPaymentMethodTypes } from '@commercetools/connect-payments-sdk';
 
 import { NotificationTokenizationDTO } from '../../dtos/adyen-payment.dto';
 import { UnsupportedNotificationError } from '../../errors/adyen-api.error';
 import { getSavedPaymentsConfig } from '../../config/saved-payment-method.config';
 
 export type NotificationTokenizationConverterResponse = {
-  draft?: PaymentMethodDraft;
+  draft?: CommercetoolsPaymentMethodTypes.SavePaymentMethodDraft;
 };
 
 export class NotificationTokenizationConverter {
@@ -27,20 +27,13 @@ export class NotificationTokenizationConverter {
 
   private async processRecurringTokenCreated(
     data: TokenizationCreatedDetailsNotificationRequest,
-  ): Promise<PaymentMethodDraft> {
+  ): Promise<CommercetoolsPaymentMethodTypes.SavePaymentMethodDraft> {
     return {
-      customer: {
-        id: data.data.shopperReference,
-        typeId: 'customer',
-      },
+      customerId: data.data.shopperReference,
+      method: data.data.type,
       paymentInterface: getSavedPaymentsConfig().config.paymentInterface,
       interfaceAccount: getSavedPaymentsConfig().config.interfaceAccount,
-      method: data.data.type,
-      default: false,
-      paymentMethodStatus: 'Active',
-      token: {
-        value: data.data.storedPaymentMethodId,
-      },
+      token: data.data.storedPaymentMethodId,
     };
   }
 }

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -173,6 +173,10 @@ export class NotificationConverter {
   }
 
   private async populateTransactions(item: NotificationRequestItem): Promise<TransactionData[]> {
+    // TODO: SCC-3447: add support for the recurring.token.created event. This is part of a new webhook called "Recurring tokens life cycle events". Which is different from the standard one.
+    // TODO: SCC-3447: The token and the rest of the payment details must be stored in the commercetools Payment entity. This must be copied over from the CoCo payment-method using the update action "setMethodInfo"
+    // TODO: SCC-3447: during the handeling of the recurring.token.created event retrieve the displayable information and store it as a custom type. Specifically: name, endDigits, brand, expireMonth, expireYear and logoUrl
+
     const transactionsMapper = this.POPULATE_TRANSACTIONS_MAPPER[item.eventCode];
     if (!transactionsMapper) {
       throw new UnsupportedNotificationError({ notificationEvent: item.eventCode.toString() });

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -14,6 +14,8 @@ import { CURRENCIES_FROM_ADYEN_TO_ISO_MAPPING } from '../../constants/currencies
 
 export class NotificationConverter {
   private ctPaymentService: CommercetoolsPaymentService;
+
+  // TODO: SCC-3447: (SCC-3449) if enabled via .env config AND success === true then if the Adyen response contains the information store it displayInfo on the Payments entity and in PaymentMethods entity
   private manageAuthorizationTransactionData = async (item: NotificationRequestItem) => [
     {
       type: 'Authorization',

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -173,10 +173,6 @@ export class NotificationConverter {
   }
 
   private async populateTransactions(item: NotificationRequestItem): Promise<TransactionData[]> {
-    // TODO: SCC-3447: add support for the recurring.token.created event. This is part of a new webhook called "Recurring tokens life cycle events". Which is different from the standard one.
-    // TODO: SCC-3447: The token and the rest of the payment details must be stored in the commercetools Payment entity. This must be copied over from the CoCo payment-method using the update action "setMethodInfo"
-    // TODO: SCC-3447: during the handeling of the recurring.token.created event retrieve the displayable information and store it as a custom type. Specifically: name, endDigits, brand, expireMonth, expireYear and logoUrl
-
     const transactionsMapper = this.POPULATE_TRANSACTIONS_MAPPER[item.eventCode];
     if (!transactionsMapper) {
       throw new UnsupportedNotificationError({ notificationEvent: item.eventCode.toString() });

--- a/processor/src/services/converters/payment-methods.converter.ts
+++ b/processor/src/services/converters/payment-methods.converter.ts
@@ -34,6 +34,7 @@ export class PaymentMethodsConverter {
       },
       countryCode: cart.country,
       merchantAccount: config.adyenMerchantAccount,
+      shopperReference: cart.customerId,
     };
   }
 


### PR DESCRIPTION
1. https://commercetools.atlassian.net/browse/SCC-3447
2. https://commercetools.atlassian.net/browse/SCC-3448
3. https://commercetools.atlassian.net/browse/SCC-3488
4. https://commercetools.atlassian.net/browse/SCC-3449

This functionalty uses the updated connect-payments-sdk for interacting with CT payment-methods. See https://github.com/commercetools/connect-payments-sdk/pull/398 and https://commercetools.atlassian.net/browse/SCC-3446

// TODO: write further high-level description of the changes and it's inner workings 