### PR TITLE
fix(billie): Solved issue that prevented sending the company name to Adyen for Billie payments

### DIFF
--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -103,30 +103,18 @@ export class CreatePaymentConverter {
 
   private populateKlarnaB2BData(cart: Cart, paymentMethodType: string): Partial<PaymentRequest> {
     const { billingAddress } = cart;
-    const { firstName, lastName, email, company } = billingAddress || {};
-
-    const hasValidBillingAddress = (): boolean => {
-      return !!(company && firstName && lastName && email);
-    };
+    const { firstName, lastName, company } = billingAddress || {};
 
     const lineItems = mapCoCoCartItemsToAdyenLineItems(cart, paymentMethodType);
-
-    if (hasValidBillingAddress()) {
-      return {
-        shopperName: {
-          firstName: firstName ?? '',
-          lastName: lastName ?? '',
-        },
-        company: {
-          name: company ?? '',
-        },
-        shopperEmail: email,
-        lineItems,
-      };
-    } else {
-      return {
-        lineItems,
-      };
-    }
+    return {
+      shopperName: {
+        firstName: firstName ?? '',
+        lastName: lastName ?? '',
+      },
+      company: {
+        name: company ?? '',
+      },
+      lineItems,
+    };
   }
 }


### PR DESCRIPTION
Company name is a required field when processing Billie payments. If that information is not sent, Adyen does not reject the payment but this is required in order to optimise the user experience. This PR fixes an issue that prevented sending that field to Adyen.

https://commercetools.atlassian.net/browse/SCC-3580