### PR TITLE
feat(payments): always send cart items information to Adyen 

### DIFF
--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -55,6 +55,7 @@ export class CreatePaymentConverter {
     const shopperStatement = getShopperStatement();
     const shopperName = extractShopperName(opts.cart);
     const storedPaymentMethodsData = await this.populateStoredPaymentMethodsData(opts.data, opts.cart);
+    const lineItems = mapCoCoCartItemsToAdyenLineItems(opts.cart, opts.data.paymentMethod?.type);
     return {
       ...requestData,
       amount: {
@@ -77,6 +78,7 @@ export class CreatePaymentConverter {
         deliveryAddress: populateCartAddress(deliveryAddress),
       }),
       ...(futureOrderNumber && { merchantOrderReference: futureOrderNumber }),
+      ...(lineItems.length > 0 && { lineItems }),
       ...this.populateAdditionalPaymentMethodData(opts.data, opts.cart),
       applicationInfo: populateApplicationInfo(),
       ...(shopperStatement && { shopperStatement }),
@@ -98,6 +100,7 @@ export class CreatePaymentConverter {
   }): Promise<PaymentRequest> {
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();
+    const lineItems = mapCoCoCartItemsToAdyenLineItems(opts.cart);
 
     const customersTokenDetailsFromAdyen = await AdyenApi().RecurringApi.getTokensForStoredPaymentDetails(
       opts.cart.customerId,
@@ -139,6 +142,7 @@ export class CreatePaymentConverter {
         deliveryAddress: populateCartAddress(deliveryAddress),
       }),
       ...(opts.futureOrderNumber && { merchantOrderReference: opts.futureOrderNumber }),
+      ...(lineItems.length > 0 && { lineItems }),
       applicationInfo: populateApplicationInfo(),
       ...(shopperStatement && { shopperStatement }),
     };
@@ -155,6 +159,7 @@ export class CreatePaymentConverter {
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();
     const shopperName = extractShopperName(opts.cart);
+    const lineItems = mapCoCoCartItemsToAdyenLineItems(opts.cart, opts.data.paymentMethod?.type);
 
     return {
       ...requestData,
@@ -178,6 +183,7 @@ export class CreatePaymentConverter {
         deliveryAddress: populateCartAddress(deliveryAddress),
       }),
       ...(futureOrderNumber && { merchantOrderReference: futureOrderNumber }),
+      ...(lineItems.length > 0 && { lineItems }),
       ...this.populateAdditionalPaymentMethodData(opts.data, opts.cart),
       applicationInfo: populateApplicationInfo(),
       ...(shopperStatement && { shopperStatement }),
@@ -277,14 +283,6 @@ export class CreatePaymentConverter {
     switch (data?.paymentMethod?.type) {
       case 'scheme':
         return this.populateAdditionalCardData();
-      case 'klarna':
-      case 'klarna_paynow':
-      case 'klarna_account':
-      case 'paypal': {
-        return {
-          lineItems: mapCoCoCartItemsToAdyenLineItems(cart, data.paymentMethod.type),
-        };
-      }
       // clearpay is the same as afterpaytouch
       case 'clearpay':
       case 'afterpaytouch': {

--- a/processor/test/config/stored-payment-method.config.spec.ts
+++ b/processor/test/config/stored-payment-method.config.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from '@jest/globals';
 import { getStoredPaymentMethodsConfig } from '../../src/config/stored-payment-methods.config';
 
 describe('stored-payment-methods.config', () => {

--- a/processor/test/services/converters/create-payment.converter.spec.ts
+++ b/processor/test/services/converters/create-payment.converter.spec.ts
@@ -463,37 +463,41 @@ describe('create-payment.converter', () => {
       const adyenTokenId = 'abcdefgh';
       const converter = new CreatePaymentConverter(paymentSDK.ctPaymentMethodService, paymentSDK.ctCartService);
 
-      const cartRandom = CartRest.random()
-        .customerId(customerId)
-        .customerEmail('johannes.vermeer@yahoo.com')
-        .shippingMode('Single')
-        .billingAddress({
-          firstName: 'Johannes',
-          lastName: 'Vermeer',
-          streetName: 'Vlamingstraat',
-          streetNumber: '42',
-          additionalStreetInfo: '',
-          postalCode: '2611 KX',
-          city: 'Delft',
-          country: 'NL',
-          phone: '+16175245223',
-          region: 'South Holland',
-          email: 'Johannes.Vermeer@example.com',
-        })
-        .shippingAddress({
-          firstName: 'Johannes',
-          lastName: 'Vermeer',
-          streetName: 'Vlamingstraat',
-          streetNumber: '42',
-          additionalStreetInfo: '',
-          postalCode: '2611 KX',
-          city: 'Delft',
-          country: 'NL',
-          phone: '+16175245223',
-          region: 'South Holland',
-          email: 'Johannes.Vermeer@example.com',
-        })
-        .buildRest<TCartRest>({}) as Cart;
+      const cartRandom: Cart = {
+        ...(CartRest.random()
+          .customerId(customerId)
+          .customerEmail('johannes.vermeer@yahoo.com')
+          .shippingMode('Single')
+          .billingAddress({
+            firstName: 'Johannes',
+            lastName: 'Vermeer',
+            streetName: 'Vlamingstraat',
+            streetNumber: '42',
+            additionalStreetInfo: '',
+            postalCode: '2611 KX',
+            city: 'Delft',
+            country: 'NL',
+            phone: '16175245223',
+            region: 'South Holland',
+            email: 'Johannes.Vermeer@example.com',
+          })
+          .shippingAddress({
+            firstName: 'Johannes',
+            lastName: 'Vermeer',
+            streetName: 'Vlamingstraat',
+            streetNumber: '42',
+            additionalStreetInfo: '',
+            postalCode: '2611 KX',
+            city: 'Delft',
+            country: 'NL',
+            phone: '16175245223',
+            region: 'South Holland',
+            email: 'Johannes.Vermeer@example.com',
+          })
+          .lineItems([])
+          .customLineItems([])
+          .buildRest<TCartRest>({}) as Cart),
+      };
 
       const paymentRandom = PaymentRest.random().id(paymentId).buildRest<TPaymentRest>({}) as Payment;
 

--- a/processor/test/services/converters/notification.recurring.spec.ts
+++ b/processor/test/services/converters/notification.recurring.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, test } from '@jest/globals';
 import {
   TokenizationCreatedDetailsNotificationRequest,
   TokenizationUpdatedDetailsNotificationRequest,


### PR DESCRIPTION
Always send the cart items information to Adyen and not only for the payment methods which explicitly require it. Reason behind is to be able to add fraud rules against this information.

https://commercetools.atlassian.net/browse/SCC-3898 