### PR TITLE
feat(gift-cards): add support for Gift cards in the dropin component

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Here you can see the details about various variables in configuration
 - `ADYEN_STORED_PAYMENT_METHODS_PAYMENT_INTERFACE`: A string value which is used to set the corresponding "paymentInterface" value on the CT payment-methods. If this value gets changed then previously created payment-methods won't be retrieved and would need to be manually migrated over.
 - `ADYEN_STORED_PAYMENT_METHODS_INTERFACE_ACCOUNT`: A string value which is used to set the corresponding "interfaceAccount" value on the CT payment-methods. If this value gets changed then previously created payment-methods won't be retrieved and would need to be manually migrated over.
 - `ADYEN_NOTIFICATION_HMAC_TOKENIZATION_WEBHOOKS_KEY`: A specific hmac key for the tokenization webhooks from Adyen. If not provided then the existing "ADYEN_NOTIFICATION_HMAC_KEY" env value is used.
+- `ADYEN_ORDER_EXPIRY_MINUTES`: Number of minutes before an Adyen Order expires for split payments (e.g. gift card + remaining method). When the order expires, Adyen sends an `ORDER_CLOSED` webhook which cancels the pending split and automatically refunds any partial payments. Default value is `60`.
 
 ## Feature
 

--- a/connect.yaml
+++ b/connect.yaml
@@ -87,6 +87,9 @@ deployAs:
         - key: ADYEN_STORE_PAYMENT_METHOD_DETAILS_ENABLED
           description: If set to "true" then displayable payment method details will be stored on the payment.paymentMethodInfo and payment-method entities. Default value is "false".
           required: false
+        - key: ADYEN_ORDER_EXPIRY_MINUTES
+          description: Number of minutes before an Adyen Order expires for split payments (e.g. gift card + remaining method). When the order expires, Adyen sends an ORDER_CLOSED webhook to cancel the pending split. Default value is "60".
+          required: false
 
       securedConfiguration:
         - key: CTP_CLIENT_SECRET

--- a/enabler/dev-utils/session.js
+++ b/enabler/dev-utils/session.js
@@ -46,7 +46,7 @@ const getSessionId = async (cartId, isDropin = false) => {
 
   const sessionMetadata = {
     processorUrl: __VITE_PROCESSOR_URL__,
-    // checkoutTransactionItemId: "006bfd77-03dd-4fdf-be5a-f6eb6714d361", // if desired for local testing set this value
+    checkoutTransactionItemId: crypto.randomUUID(),
     ...(!isDropin && {
       allowedPaymentMethods: [
         "afterpay",

--- a/enabler/src/api/processor-api.client.ts
+++ b/enabler/src/api/processor-api.client.ts
@@ -1,0 +1,195 @@
+import { balanceCheckResponseType, GiftCardElementData } from '@adyen/adyen-web';
+import {
+  ConfigResponse,
+  CreateSessionRequest,
+  CreateSessionResponse,
+  StoredPaymentMethodsResponse,
+  CreatePaymentRequest,
+  CreatePaymentResponse,
+  ConfirmPaymentDetailsRequest,
+  ConfirmPaymentDetailsResponse,
+  CreateApplePaySessionRequest,
+  CreateApplePaySessionResponse,
+  ExpressConfigRequest,
+  ExpressConfigResponse,
+  ExpressPaymentDataResponse,
+  CreateExpressPaymentRequest,
+  CreateExpressPaymentResponse,
+  ConfirmExpressPaymentDetailsRequest,
+  ConfirmExpressPaymentDetailsResponse,
+  UpdatePaypalOrderRequest,
+  UpdatePaypalOrderResponse,
+  CreateOrderResponse,
+  CancelOrderRequest,
+  CancelOrderResponse,
+} from './processor-api.type';
+
+export class ProcessorApiClient {
+  private readonly host: string;
+  private readonly sessionId: string;
+
+  constructor(opts: { processorUrl: string; sessionId: string }) {
+    this.host = opts.processorUrl.replace(/\/$/, '');
+    this.sessionId = opts.sessionId;
+  }
+
+  private get authHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'X-Session-Id': this.sessionId,
+    };
+  }
+
+  // ─── Session & Configuration ──────────────────────────────────────────────
+
+  async createSession(data: CreateSessionRequest): Promise<CreateSessionResponse> {
+    const res = await fetch(`${this.host}/sessions`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to create session (${res.status})`);
+    return res.json();
+  }
+
+  async getConfig(): Promise<ConfigResponse> {
+    const res = await fetch(`${this.host}/operations/config`, {
+      method: 'GET',
+      headers: this.authHeaders,
+    });
+    if (!res.ok) throw new Error(`Failed to get config (${res.status})`);
+    return res.json();
+  }
+
+  async getStoredPaymentMethods(): Promise<StoredPaymentMethodsResponse> {
+    const res = await fetch(`${this.host}/stored-payment-methods`, {
+      method: 'GET',
+      headers: this.authHeaders,
+    });
+    if (!res.ok) throw new Error(`Failed to get stored payment methods (${res.status})`);
+    return res.json();
+  }
+
+  async deleteStoredPaymentMethod(id: string): Promise<void> {
+    const res = await fetch(`${this.host}/stored-payment-methods/${id}`, {
+      method: 'DELETE',
+      headers: { 'X-Session-Id': this.sessionId },
+    });
+    if (!res.ok) throw new Error(`Failed to delete stored payment method (${res.status})`);
+  }
+
+  // ─── Payments ──────────────────────────────────────────────────────
+
+  async createPayment(data: CreatePaymentRequest): Promise<CreatePaymentResponse> {
+    const res = await fetch(`${this.host}/payments`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to create payment (${res.status})`);
+    return res.json();
+  }
+
+  async confirmPaymentDetails(data: ConfirmPaymentDetailsRequest): Promise<ConfirmPaymentDetailsResponse> {
+    const res = await fetch(`${this.host}/payments/details`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to confirm payment details (${res.status})`);
+    return res.json();
+  }
+
+  async checkGiftCardBalance(data: GiftCardElementData): Promise<balanceCheckResponseType> {
+    const res = await fetch(`${this.host}/paymentMethods/balance`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to check gift card balance (${res.status})`);
+    return res.json();
+  }
+
+  async createApplePaySession(data: CreateApplePaySessionRequest): Promise<CreateApplePaySessionResponse> {
+    const res = await fetch(`${this.host}/applepay-sessions`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to create Apple Pay session (${res.status})`);
+    return res.json();
+  }
+
+  // ─── Express payments ─────────────────────────────────────────────────────
+
+  async getExpressConfig(data: ExpressConfigRequest): Promise<ExpressConfigResponse> {
+    const res = await fetch(`${this.host}/express-config`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to get express config (${res.status})`);
+    return res.json();
+  }
+
+  async getExpressPaymentData(): Promise<ExpressPaymentDataResponse> {
+    const res = await fetch(`${this.host}/express-payment-data`, {
+      method: 'GET',
+      headers: this.authHeaders,
+    });
+    if (!res.ok) throw new Error(`Failed to get express payment data (${res.status})`);
+    return res.json();
+  }
+
+  async createExpressPayment(data: CreateExpressPaymentRequest): Promise<CreateExpressPaymentResponse> {
+    const res = await fetch(`${this.host}/express-payments`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to create express payment (${res.status})`);
+    return res.json();
+  }
+
+  async confirmExpressPaymentDetails(data: ConfirmExpressPaymentDetailsRequest): Promise<ConfirmExpressPaymentDetailsResponse> {
+    const res = await fetch(`${this.host}/express-payments/details`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to confirm express payment details (${res.status})`);
+    return res.json();
+  }
+
+  async updatePaypalOrder(data: UpdatePaypalOrderRequest): Promise<UpdatePaypalOrderResponse> {
+    const res = await fetch(`${this.host}/paypal-express/order`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to update PayPal order (${res.status})`);
+    return res.json();
+  }
+
+  // ─── Orders (gift card split payments) ───────────────────────────────────
+
+  async createOrder(): Promise<CreateOrderResponse> {
+    const res = await fetch(`${this.host}/orders`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) throw new Error(`Failed to create order (${res.status})`);
+    return res.json();
+  }
+
+  async cancelOrder(data: CancelOrderRequest): Promise<CancelOrderResponse> {
+    const res = await fetch(`${this.host}/orders/cancel`, {
+      method: 'POST',
+      headers: this.authHeaders,
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) throw new Error(`Failed to cancel order (${res.status})`);
+    return res.json();
+  }
+}

--- a/enabler/src/api/processor-api.type.ts
+++ b/enabler/src/api/processor-api.type.ts
@@ -1,0 +1,105 @@
+import { CTAmount, CocoStoredPaymentMethod } from '../payment-enabler/payment-enabler';
+import { CoreConfiguration, PaymentAction, RawPaymentMethod, ResultCode } from '@adyen/adyen-web';
+
+type AdyenEnvironment = CoreConfiguration['environment'];
+
+// ─── Session & Configuration ──────────────────────────────────────────────────
+
+export type CreateSessionRequest = { shopperLocale: string };
+export type CreateSessionResponse = {
+  sessionData: { id: string; sessionData: string };
+};
+
+export type ConfigResponse = {
+  environment: AdyenEnvironment;
+  clientKey: string;
+  applePayConfig?: { usesOwnCertificate: boolean };
+  paymentComponentsConfig?: Record<string, Record<string, unknown>>;
+  storedPaymentMethodsConfig?: { isEnabled: boolean };
+};
+
+export type StoredPaymentMethodsResponse = {
+  storedPaymentMethods: CocoStoredPaymentMethod[];
+};
+
+// ─── Payments ──────────────────────────────────────────────────────────
+
+export type CreatePaymentRequest = Record<string, unknown>;
+export type CreatePaymentResponse = {
+  resultCode: ResultCode;
+  action?: PaymentAction;
+  order?: { orderData: string; pspReference: string; remainingAmount?: { value: number; currency: string } };
+  paymentReference: string;
+};
+
+export type ConfirmPaymentDetailsRequest = Record<string, unknown>;
+export type ConfirmPaymentDetailsResponse = { resultCode: ResultCode };
+
+export type CreateApplePaySessionRequest = { validationUrl: string };
+export type CreateApplePaySessionResponse = Record<string, unknown>;
+
+// ─── Express payments ─────────────────────────────────────────────────────────
+
+export type ExpressConfigRequest = { countryCode: string };
+export type ExpressConfigResponse = {
+  config: {
+    environment: AdyenEnvironment;
+    clientKey: string;
+    applePayConfig?: { usesOwnCertificate: boolean };
+  };
+  methods: Array<{ type: string; configuration: Record<string, string> }>;
+};
+
+export type ExpressPaymentDataResponse = {
+  totalPrice: CTAmount;
+  lineItems: Array<{ name: string; amount: CTAmount; type: string }>;
+  currencyCode: string;
+};
+
+export type CreateExpressPaymentRequest = Record<string, unknown>;
+export type CreateExpressPaymentResponse = {
+  resultCode: ResultCode;
+  action?: PaymentAction;
+  paymentReference?: string;
+};
+
+export type ConfirmExpressPaymentDetailsRequest = Record<string, unknown>;
+export type ConfirmExpressPaymentDetailsResponse = {
+  resultCode: ResultCode;
+  paymentReference?: string;
+  paymentMethod?: RawPaymentMethod;
+};
+
+export type UpdatePaypalOrderRequest = {
+  paymentReference?: string;
+  pspReference: string;
+  paymentData: string;
+  deliveryMethods: Array<{
+    reference: string;
+    description: string;
+    type: string;
+    amount: { currency: string; value: number };
+    selected: boolean;
+  }>;
+  originalAmount: CTAmount;
+};
+export type UpdatePaypalOrderResponse = Record<string, unknown>;
+
+// ─── Orders (gift card split payments) ───────────────────────────────────────
+
+export type CreateOrderResponse = {
+  orderData: string;
+  pspReference?: string;
+  amount: { value: number; currency: string };
+  remainingAmount: { value: number; currency: string };
+};
+
+export type CancelOrderRequest = {
+  orderData: string;
+  pspReference: string;
+};
+
+export type CancelOrderResponse = {
+  pspReference: string;
+  resultCode: string;
+};

--- a/enabler/src/components/base.ts
+++ b/enabler/src/components/base.ts
@@ -25,6 +25,7 @@ import {
   PaymentMethod,
 } from "../payment-enabler/payment-enabler";
 import { BaseOptions } from "../payment-enabler/adyen-payment-enabler";
+import { ProcessorApiClient } from '../api/processor-api.client';
 
 type AdyenComponent =
   | Card
@@ -88,6 +89,7 @@ export abstract class DefaultAdyenComponent implements PaymentComponent {
   protected processorUrl: string;
   protected paymentComponentConfigOverride: Record<string, any>;
   protected setStorePaymentDetails?: (enabled: boolean) => void;
+  protected apiClient: ProcessorApiClient;
 
   constructor(opts: {
     paymentMethod: PaymentMethod;
@@ -105,6 +107,7 @@ export abstract class DefaultAdyenComponent implements PaymentComponent {
     this.processorUrl = opts.processorUrl;
     this.paymentComponentConfigOverride = opts.paymentComponentConfigOverride;
     this.setStorePaymentDetails = opts.setStorePaymentDetails;
+    this.apiClient = new ProcessorApiClient({ processorUrl: opts.processorUrl, sessionId: opts.sessionId });
   }
   abstract init(): void;
 

--- a/enabler/src/components/payment-methods/applepay.ts
+++ b/enabler/src/components/payment-methods/applepay.ts
@@ -72,22 +72,8 @@ export class ApplePayComponent extends DefaultAdyenComponent {
   }
 
   private onValidateMerchant(resolve: Function, reject: Function, validationUrl: string) {
-    fetch(`${this.processorUrl}/applepay-sessions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Session-Id": this.sessionId,
-      },
-      body: JSON.stringify({
-        validationUrl,
-      }),
-    })
-      .then((res) => res.json())
-      .then((merchantSession) => {
-        resolve(merchantSession);
-      })
-      .catch((error) => {
-        reject(error);
-      });
+    this.apiClient.createApplePaySession({ validationUrl })
+      .then((merchantSession) => { resolve(merchantSession); })
+      .catch((error) => { reject(error); });
   }
 }

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -10,6 +10,7 @@ import {
   BaseOptions,
   StoredPaymentMethodsConfig,
 } from "../payment-enabler/adyen-payment-enabler";
+import { ProcessorApiClient } from "../api/processor-api.client";
 import {
   ICore,
   SubmitActions,
@@ -34,6 +35,7 @@ import {
   MolPayEBankingMY,
   Trustly,
   MBWay,
+  Giftcard,
 } from "@adyen/adyen-web";
 
 export class DropinEmbeddedBuilder implements PaymentDropinBuilder {
@@ -77,9 +79,8 @@ export class DropinComponents implements DropinComponent {
   private adyenCheckout: ICore;
   private dropinOptions: DropinOptions;
   private dropinConfigOverride: Record<string, any>;
-  private processorUrl: string;
-  private sessionId: string;
   private storedPaymentMethodsConfig: StoredPaymentMethodsConfig;
+  private apiClient: ProcessorApiClient;
 
   constructor(opts: {
     adyenCheckout: ICore;
@@ -93,8 +94,7 @@ export class DropinComponents implements DropinComponent {
     this.adyenCheckout = opts.adyenCheckout;
     this.dropinConfigOverride = opts.dropinConfigOverride;
     this.storedPaymentMethodsConfig = opts.storedPaymentMethodsConfig;
-    this.processorUrl = opts.processorUrl;
-    this.sessionId = opts.sessionId;
+    this.apiClient = new ProcessorApiClient({ processorUrl: opts.processorUrl, sessionId: opts.sessionId });
 
     this.overrideOnSubmit();
   }
@@ -108,45 +108,27 @@ export class DropinComponents implements DropinComponent {
       showRemovePaymentMethodButton: this.storedPaymentMethodsConfig.isEnabled,
       filterStoredPaymentMethods: (storedPaymentMethods) => {
         return storedPaymentMethods.filter((spm) => {
-          const ctStoredPaymentMethod =
-            this.storedPaymentMethodsConfig.storedPaymentMethods.find(
-              (ctSpm) => ctSpm.token === spm.id,
-            );
+          const ctStoredPaymentMethod = this.storedPaymentMethodsConfig.storedPaymentMethods.find(
+            (ctSpm) => ctSpm.token === spm.id,
+          );
 
           return ctStoredPaymentMethod !== undefined;
         });
       },
-      onDisableStoredPaymentMethod: async (
-        storedPaymentMethod,
-        resolve,
-        reject,
-      ) => {
-        const ctStoredPaymentMethod =
-          this.storedPaymentMethodsConfig.storedPaymentMethods.find((spm) => {
-            return spm.token === storedPaymentMethod;
-          });
+      onDisableStoredPaymentMethod: async (storedPaymentMethod, resolve, reject) => {
+        const ctStoredPaymentMethod = this.storedPaymentMethodsConfig.storedPaymentMethods.find((spm) => {
+          return spm.token === storedPaymentMethod;
+        });
 
         if (!ctStoredPaymentMethod) {
-          console.log(
-            "Drop-in component return an token id which is not known",
-          );
+          console.log("Drop-in component return an token id which is not known");
           return reject();
         }
 
-        const url = this.processorUrl.endsWith("/")
-          ? `${this.processorUrl}stored-payment-methods/${ctStoredPaymentMethod.id}`
-          : `${this.processorUrl}/stored-payment-methods/${ctStoredPaymentMethod.id}`;
-
-        const response = await fetch(url, {
-          method: "DELETE",
-          headers: {
-            "X-Session-Id": this.sessionId,
-          },
-        });
-
-        if (response.ok) {
+        try {
+          await this.apiClient.deleteStoredPaymentMethod(ctStoredPaymentMethod.id);
           return resolve();
-        } else {
+        } catch {
           return reject();
         }
       },
@@ -177,16 +159,15 @@ export class DropinComponents implements DropinComponent {
         Vipps,
         AfterPay,
         Trustly,
-        MBWay
+        MBWay,
+        Giftcard,
       ],
       paymentMethodsConfiguration: {
         applepay: {
           buttonType: "pay" as any, // "pay" type is not included in Adyen's types, try to force it
           buttonColor: "black",
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.applepay)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.applepay)],
           // Configuration that can not be overridden
           onClick: (resolve, reject) => {
             if (this.dropinOptions.onPayButtonClick) {
@@ -200,25 +181,19 @@ export class DropinComponents implements DropinComponent {
         },
         bcmc: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.bancontactcard)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.bancontactcard)],
           // Configuration that can not be overridden
         },
         bcmc_mobile: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.bancontactmobile)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.bancontactmobile)],
           // Configuration that can not be overridden
         },
         card: {
           hasHolderName: true,
           holderNameRequired: true,
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.card)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.card)],
           // Configuration that can not be overridden
           enableStoreDetails: this.storedPaymentMethodsConfig.isEnabled,
         },
@@ -226,9 +201,7 @@ export class DropinComponents implements DropinComponent {
           buttonType: "pay",
           buttonSizeMode: "fill",
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.googlepay)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.googlepay)],
           // Configuration that can not be overridden
           onClick: (resolve, reject) => {
             if (this.dropinOptions.onPayButtonClick) {
@@ -242,30 +215,22 @@ export class DropinComponents implements DropinComponent {
         },
         klarna_b2b: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.klarna_billie)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_billie)],
           // Configuration that can not be overridden
         },
         klarna: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.klarna_pay_later)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_later)],
           // Configuration that can not be overridden
         },
         klarna_paynow: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.klarna_pay_now)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_now)],
           // Configuration that can not be overridden
         },
         klarna_account: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.klarna_pay_overtime)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.klarna_pay_overtime)],
           // Configuration that can not be overridden
         },
         molpay_ebanking_fpx_MY: {
@@ -275,9 +240,7 @@ export class DropinComponents implements DropinComponent {
         },
         onlineBanking_PL: {
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.przelewy24)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.przelewy24)],
           // Configuration that can not be overridden
         },
         paypal: {
@@ -285,9 +248,7 @@ export class DropinComponents implements DropinComponent {
           blockPayPalPayLaterButton: true,
           blockPayPalVenmoButton: true,
           // Override the default config with the one provided by the user
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.paypal)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.paypal)],
           // Configuration that can not be overridden
           style: {
             disableMaxWidth: true,
@@ -304,15 +265,11 @@ export class DropinComponents implements DropinComponent {
           },
         },
         trustly: {
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.trustly)
-          ],
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.trustly)],
         },
         mbway: {
-          ...this.dropinConfigOverride[
-            getPaymentMethodType(PaymentMethod.mbway)
-          ],
-        }
+          ...this.dropinConfigOverride[getPaymentMethodType(PaymentMethod.mbway)],
+        },
       },
     });
   }
@@ -322,23 +279,17 @@ export class DropinComponents implements DropinComponent {
   }
 
   async submit(): Promise<void> {
-    throw new Error(
-      "Method not available. Submit is managed by the Dropin component.",
-    );
+    throw new Error("Method not available. Submit is managed by the Dropin component.");
   }
 
   private overrideOnSubmit() {
     const parentOnSubmit = this.adyenCheckout.options.onSubmit;
 
-    this.adyenCheckout.options.onSubmit = async (
-      state: SubmitData,
-      component: Dropin,
-      actions: SubmitActions,
-    ) => {
+    this.adyenCheckout.options.onSubmit = async (state: SubmitData, component: Dropin, actions: SubmitActions) => {
       const paymentMethod = state.data.paymentMethod.type;
-      const hasOnClick =
-        component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
-      if (!hasOnClick && this.dropinOptions.onPayButtonClick) {
+      const hasOnClick = component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
+      const isGiftCardResubmit = paymentMethod === 'giftcard' && !!state.data.order;
+      if (!hasOnClick && !isGiftCardResubmit && this.dropinOptions.onPayButtonClick) {
         try {
           await this.dropinOptions.onPayButtonClick();
         } catch (e) {

--- a/enabler/src/dropin/dropin-embedded.ts
+++ b/enabler/src/dropin/dropin-embedded.ts
@@ -287,7 +287,7 @@ export class DropinComponents implements DropinComponent {
 
     this.adyenCheckout.options.onSubmit = async (state: SubmitData, component: Dropin, actions: SubmitActions) => {
       const paymentMethod = state.data.paymentMethod.type;
-      const hasOnClick = component.props.paymentMethodsConfiguration[paymentMethod]?.onClick;
+      const hasOnClick = component.props.paymentMethodsConfiguration?.[paymentMethod]?.onClick;
       const isGiftCardResubmit = paymentMethod === 'giftcard' && !!state.data.order;
       if (!hasOnClick && !isGiftCardResubmit && this.dropinOptions.onPayButtonClick) {
         try {

--- a/enabler/src/express/applepay.ts
+++ b/enabler/src/express/applepay.ts
@@ -266,23 +266,9 @@ export class ApplePayExpressComponent extends DefaultAdyenExpressComponent {
     reject: Function,
     validationUrl: string
   ) {
-    fetch(`${this.processorUrl}/applepay-sessions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Session-Id": this.sessionId,
-      },
-      body: JSON.stringify({
-        validationUrl,
-      }),
-    })
-      .then((res) => res.json())
-      .then((merchantSession) => {
-        resolve(merchantSession);
-      })
-      .catch((error) => {
-        reject(error);
-      });
+    this.apiClient.createApplePaySession({ validationUrl })
+      .then((merchantSession) => { resolve(merchantSession); })
+      .catch((error) => { reject(error); });
   }
 
   private async getLineItemsWithNewTotal(

--- a/enabler/src/express/base.ts
+++ b/enabler/src/express/base.ts
@@ -8,27 +8,21 @@ import {
   UIElement,
 } from "@adyen/adyen-web";
 import {
-  CTAmount,
   ExpressAddressData,
   ExpressComponent,
   ExpressOptions,
   ExpressShippingOptionData,
   OnComplete,
 } from "../payment-enabler/payment-enabler";
+import { ProcessorApiClient } from '../api/processor-api.client';
+import { ExpressPaymentDataResponse } from '../api/processor-api.type';
 
 export type ShippingMethodCost = {
   [key: string]: string;
 };
 
-export type InitialPaymentData = {
-  totalPrice: CTAmount;
-  lineItems: {
-    name: string;
-    amount: CTAmount;
-    type: string;
-  }[];
-  currencyCode: string;
-};
+// Re-export for backwards compatibility with subclasses that reference InitialPaymentData
+export type InitialPaymentData = ExpressPaymentDataResponse;
 
 export abstract class DefaultAdyenExpressComponent implements ExpressComponent {
   protected processorUrl: string;
@@ -40,6 +34,7 @@ export abstract class DefaultAdyenExpressComponent implements ExpressComponent {
   protected availableShippingMethods: ExpressShippingOptionData[];
   protected paymentMethodConfig: { [key: string]: string };
   protected onComplete: OnComplete;
+  protected apiClient: ProcessorApiClient;
 
   constructor(opts: {
     expressOptions: ExpressOptions;
@@ -57,6 +52,7 @@ export abstract class DefaultAdyenExpressComponent implements ExpressComponent {
     this.currencyCode = opts.currencyCode;
     this.paymentMethodConfig = opts.paymentMethodConfig;
     this.onComplete = opts.onComplete;
+    this.apiClient = new ProcessorApiClient({ processorUrl: opts.processorUrl, sessionId: opts.sessionId });
   }
 
   abstract init(): void;
@@ -114,23 +110,12 @@ export abstract class DefaultAdyenExpressComponent implements ExpressComponent {
 
   protected setSessionId(sessionId): void {
     this.sessionId = sessionId;
+    this.apiClient = new ProcessorApiClient({ processorUrl: this.processorUrl, sessionId });
   }
 
   protected async getInitialPaymentData(): Promise<InitialPaymentData> {
     try {
-      const response = await fetch(
-        `${this.processorUrl}/express-payment-data`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Session-Id": this.sessionId,
-          },
-        }
-      );
-      
-      const data = await response.json();
-      return data as InitialPaymentData;
+      return await this.apiClient.getExpressPaymentData();
     } catch (error) {
       console.error("## getPaymentData - critical error", error);
       throw error;
@@ -192,16 +177,7 @@ export abstract class DefaultAdyenExpressComponent implements ExpressComponent {
         ...opts.extraRequestData,
       };
 
-      const response = await fetch(this.processorUrl + "/express-payments", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Session-Id": this.sessionId,
-        },
-        body: JSON.stringify(reqData),
-      });
-
-      const data = await response.json();
+      const data = await this.apiClient.createExpressPayment(reqData);
 
       if (opts.onBeforeResolve) {
         opts.onBeforeResolve(data);

--- a/enabler/src/express/paypal.ts
+++ b/enabler/src/express/paypal.ts
@@ -15,6 +15,7 @@ import {
 } from "../payment-enabler/payment-enabler";
 import { BaseOptions } from "../payment-enabler/adyen-payment-enabler";
 import { DefaultAdyenExpressComponent } from "./base";
+import { UpdatePaypalOrderRequest } from "../api/processor-api.type";
 
 type PayPalShippingOption = {
   reference: string;
@@ -25,14 +26,6 @@ type PayPalShippingOption = {
     value: number;
   };
   selected: boolean;
-};
-
-type UpdateOrder = {
-  paymentReference?: string;
-  pspReference: string;
-  paymentData: string;
-  deliveryMethods: PayPalShippingOption[];
-  originalAmount: CTAmount;
 };
 
 /**
@@ -79,11 +72,11 @@ export class PayPalExpressBuilder implements PaymentExpressBuilder {
 
 export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
   private adyenCheckout: ICore;
-  private pspReference: string;
-  private paymentReference: string;
+  private pspReference!: string;
+  private paymentReference!: string;
   private shippingAddress: any;
-  private originalAmount: CTAmount;
-  private paymentMethod: RawPaymentMethod;
+  private originalAmount!: CTAmount;
+  private paymentMethod!: RawPaymentMethod;
 
   constructor(opts: {
     adyenCheckout: ICore;
@@ -107,19 +100,12 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
     this.adyenCheckout = opts.adyenCheckout;
   }
 
-  private validateShippingAddressCountry(data?: {
-    shippingAddress?: { countryCode: string };
-  }): boolean {
+  private validateShippingAddressCountry(data?: { shippingAddress?: { countryCode: string } }): boolean {
     if (!data?.shippingAddress?.countryCode) return false;
-    if (
-      !this.expressOptions.allowedCountries ||
-      this.expressOptions.allowedCountries.length === 0
-    ) {
+    if (!this.expressOptions.allowedCountries || this.expressOptions.allowedCountries.length === 0) {
       return true;
     }
-    return this.expressOptions.allowedCountries.includes(
-      data.shippingAddress.countryCode
-    );
+    return this.expressOptions.allowedCountries.includes(data.shippingAddress.countryCode);
   }
 
   init(): void {
@@ -155,11 +141,7 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
           method: this.paymentMethod,
         });
       },
-      onSubmit: async (
-        state: SubmitData,
-        component: UIElement,
-        actions: SubmitActions
-      ) => {
+      onSubmit: async (state: SubmitData, component: UIElement, actions: SubmitActions) => {
         return this.submit({
           state,
           component,
@@ -189,16 +171,12 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
             },
           });
 
-          const shippingOptions = await me.getShippingOptions(
-            data.shippingAddress.countryCode
-          );
+          const shippingOptions = await me.getShippingOptions(data.shippingAddress.countryCode);
 
           this.shippingAddress = data.shippingAddress;
 
           // set the default shipping option at this point in the cart.
-          const selectedOption = shippingOptions.filter(
-            (option) => option.selected === true
-          );
+          const selectedOption = shippingOptions.filter((option) => option.selected === true);
           await me.setShippingMethod({
             shippingMethod: {
               id: selectedOption[0].reference,
@@ -209,7 +187,7 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
           const payload = {
             paymentReference: this.paymentReference,
             pspReference: this.pspReference,
-            paymentData: component.paymentData,
+            paymentData: component.paymentData ?? "",
             deliveryMethods: shippingOptions,
             originalAmount: this.originalAmount,
           };
@@ -231,13 +209,13 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
           // fetch all shipping methods
           const shippingOptions = await me.getShippingOptions(
             this.shippingAddress.countryCode,
-            data.selectedShippingOption.id
+            data.selectedShippingOption.id,
           );
 
           const payload = {
             paymentReference: this.paymentReference,
             pspReference: this.pspReference,
-            paymentData: component.paymentData,
+            paymentData: component.paymentData ?? "",
             deliveryMethods: shippingOptions,
             originalAmount: this.originalAmount,
           };
@@ -251,32 +229,17 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
       },
       onAdditionalDetails: async (state, component, actions) => {
         try {
-          const requestData = {
+          const data = await this.apiClient.confirmExpressPaymentDetails({
             ...state.data,
             paymentReference: this.paymentReference,
             paymentMethod: this.paymentMethod.type,
-          };
-          const url = this.processorUrl.endsWith("/")
-            ? `${this.processorUrl}express-payments/details`
-            : `${this.processorUrl}/express-payments/details`;
-
-          const response = await fetch(url, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Session-Id": this.sessionId,
-            },
-            body: JSON.stringify(requestData),
           });
-
-          const data = await response.json();
           this.paymentReference = data.paymentReference;
-          this.paymentMethod = data.paymentMethod;
+          if (data.paymentMethod) {
+            this.paymentMethod = data.paymentMethod;
+          }
 
-          if (
-            data.resultCode === "Authorised" ||
-            data.resultCode === "Pending"
-          ) {
+          if (data.resultCode === "Authorised" || data.resultCode === "Pending") {
             component.setStatus("success");
           } else {
             component.setStatus("error");
@@ -287,12 +250,9 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
         }
       },
       onAuthorized: async (data, actions) => {
-        const deliveryInformation =
-          data.authorizedEvent.purchase_units[0]?.shipping;
+        const deliveryInformation = data.authorizedEvent.purchase_units[0]?.shipping;
 
-        const deliveryName = this.safelyParseShippingName(
-          deliveryInformation?.name?.full_name
-        );
+        const deliveryName = this.safelyParseShippingName(deliveryInformation?.name?.full_name);
 
         const customerEmail = data.authorizedEvent.payer.email_address;
 
@@ -309,8 +269,7 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
           email: customerEmail,
           firstName: data.authorizedEvent.payer?.name?.given_name || "",
           lastName: data.authorizedEvent.payer?.name?.surname || "",
-          phoneNumber:
-            data.authorizedEvent.payer.phone?.phone_number?.national_number,
+          phoneNumber: data.authorizedEvent.payer.phone?.phone_number?.national_number,
         });
 
         this.expressOptions
@@ -327,34 +286,11 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
     });
   }
 
-  protected async updateOrder(payload: UpdateOrder): Promise<any> {
-    try {
-      const response = await fetch(
-        `${this.processorUrl}/paypal-express/order`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Session-Id": this.sessionId,
-          },
-          body: JSON.stringify(payload),
-        }
-      );
-      if (!response.ok) {
-        throw new Error("something happened.");
-      }
-
-      const data = await response.json();
-      return data;
-    } catch (error) {
-      throw error;
-    }
+  protected async updateOrder(payload: UpdatePaypalOrderRequest): Promise<any> {
+    return this.apiClient.updatePaypalOrder(payload);
   }
 
-  private async getShippingOptions(
-    countryCode: string,
-    selectedOptionId?: string
-  ): Promise<PayPalShippingOption[]> {
+  private async getShippingOptions(countryCode: string, selectedOptionId?: string): Promise<PayPalShippingOption[]> {
     const shippingMethods = await this.getShippingMethods({
       address: { country: countryCode },
     });
@@ -367,10 +303,7 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
         currency: method.amount.currencyCode,
         value: method.amount.centAmount, //HINT: an iso to adyen mapping is done for this value in the processor before being sent to adyen.
       },
-      selected:
-        selectedOptionId !== undefined
-          ? selectedOptionId === method.id
-          : method.isSelected ?? false,
+      selected: selectedOptionId !== undefined ? selectedOptionId === method.id : (method.isSelected ?? false),
     }));
   }
 
@@ -378,11 +311,7 @@ export class PayPalExpressComponent extends DefaultAdyenExpressComponent {
     firstName: string;
     lastName: string;
   } {
-    const parts = (fullName || "")
-      .trim()
-      .replace(/\s+/g, " ")
-      .split(" ")
-      .filter(Boolean);
+    const parts = (fullName || "").trim().replace(/\s+/g, " ").split(" ").filter(Boolean);
 
     return {
       firstName: parts[0] || "",

--- a/enabler/src/payment-enabler/adyen-init-advanced.ts
+++ b/enabler/src/payment-enabler/adyen-init-advanced.ts
@@ -8,6 +8,7 @@ import { convertToAdyenLocale } from "../converters/locale.converter";
 import { AdyenInit } from "./adyen-init-session";
 import { AdyenEnablerOptions, BaseOptions } from "./adyen-payment-enabler";
 import { getPaymentMethodType } from "./payment-enabler";
+import { ProcessorApiClient } from '../api/processor-api.client';
 
 class AdyenInitError extends Error {
   sessionId: string;
@@ -20,11 +21,13 @@ class AdyenInitError extends Error {
 
 export class AdyenInitWithAdvancedFlow implements AdyenInit {
   private initOptions: AdyenEnablerOptions;
+  private apiClient: ProcessorApiClient;
   private applePayConfig?: { usesOwnCertificate: boolean };
   private expressPaymentMethodsConfig: Map<string, { [key: string]: string }>;
 
   constructor(initOptions: AdyenEnablerOptions) {
     this.initOptions = initOptions;
+    this.apiClient = new ProcessorApiClient({ processorUrl: initOptions.processorUrl, sessionId: initOptions.sessionId });
     this.expressPaymentMethodsConfig = new Map();
   }
 
@@ -33,33 +36,11 @@ export class AdyenInitWithAdvancedFlow implements AdyenInit {
       this.initOptions.locale || "en-US"
     );
 
-    const [configResponse] = await Promise.all([
-      fetch(`${this.initOptions.processorUrl}/express-config`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          countryCode: this.initOptions.countryCode,
-        }),
-      }),
-    ]);
-
-    if (!configResponse.ok) {
-      throw new AdyenInitError(
-        configResponse.status === 403
-          ? "Unauthorized error fetching express config"
-          : "Not able to initialize Adyen"
-      );
-    }
-
-    const [configJson] = await Promise.all([configResponse.json()]);
-
-    if (!configJson.methods) {
-      throw new AdyenInitError(
-        "Not able to initialize Adyen",
-        this.initOptions.sessionId
-      );
+    let configJson: Awaited<ReturnType<ProcessorApiClient['getExpressConfig']>>;
+    try {
+      configJson = await this.apiClient.getExpressConfig({ countryCode: this.initOptions.countryCode });
+    } catch {
+      throw new AdyenInitError('Not able to initialize Adyen', this.initOptions.sessionId);
     }
 
     configJson.methods.forEach((method: any) => {
@@ -108,7 +89,7 @@ export class AdyenInitWithAdvancedFlow implements AdyenInit {
   private handleError(opts: { error: any; component: UIElement }) {
     if (this.initOptions.onError) {
       this.initOptions.onError(opts.error, {
-        method: { type: getPaymentMethodType(opts.component?.props?.type) },
+        method: opts.component?.props?.type ? { type: getPaymentMethodType(opts.component.props.type) } : undefined,
       });
     }
   }
@@ -122,7 +103,7 @@ export class AdyenInitWithAdvancedFlow implements AdyenInit {
       this.initOptions.onComplete({
         isSuccess: opts.isSuccess,
         paymentReference: opts?.paymentReference,
-        method: { type: getPaymentMethodType(opts.component?.props?.type) },
+        method: { type: getPaymentMethodType(opts.component.props?.type) },
       });
     }
   }

--- a/enabler/src/payment-enabler/adyen-init-session.ts
+++ b/enabler/src/payment-enabler/adyen-init-session.ts
@@ -19,6 +19,7 @@ import {
   CocoStoredPaymentMethod,
   getPaymentMethodType,
 } from "./payment-enabler";
+import { ProcessorApiClient } from '../api/processor-api.client';
 
 export interface AdyenInit {
   init(type: string): Promise<BaseOptions>;
@@ -35,6 +36,7 @@ class AdyenInitError extends Error {
 
 export class AdyenInitWithSessionFlow implements AdyenInit {
   private initOptions: AdyenEnablerOptions;
+  private apiClient: ProcessorApiClient;
   private applePayConfig?: { usesOwnCertificate: boolean };
   private storedPaymentMethodsConfig: StoredPaymentMethodsConfig;
   private paymentComponentsConfigOverride?: Record<string, any>;
@@ -42,6 +44,7 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
 
   constructor(initOptions: AdyenEnablerOptions) {
     this.initOptions = initOptions;
+    this.apiClient = new ProcessorApiClient({ processorUrl: initOptions.processorUrl, sessionId: initOptions.sessionId });
   }
 
   async init(): Promise<BaseOptions> {
@@ -49,52 +52,20 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
       this.initOptions.locale || "en-US"
     );
 
-    const [sessionResponse, configResponse] = await Promise.all([
-      fetch(`${this.initOptions.processorUrl}/sessions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Session-Id": this.initOptions.sessionId,
-        },
-        body: JSON.stringify({
-          shopperLocale: adyenLocale,
-        }),
-      }),
-      fetch(`${this.initOptions.processorUrl}/operations/config`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Session-Id": this.initOptions.sessionId,
-        },
-      }),
-    ]);
-
     const [sessionJson, configJson] = await Promise.all([
-      sessionResponse.json(),
-      configResponse.json(),
+      this.apiClient.createSession({ shopperLocale: adyenLocale }),
+      this.apiClient.getConfig(),
     ]);
 
+    let orderAmount: { value: number; currency: string } | undefined;
     let storedPaymentMethodsList: CocoStoredPaymentMethod[] = [];
     if (configJson.storedPaymentMethodsConfig?.isEnabled === true) {
-      const response = await fetch(
-        this.initOptions.processorUrl + "/stored-payment-methods",
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Session-Id": this.initOptions.sessionId,
-          },
-        }
-      );
-
-      const storedPaymentMethods: {
-        storedPaymentMethods: CocoStoredPaymentMethod[];
-      } = await response.json();
-
+      const storedPaymentMethods = await this.apiClient.getStoredPaymentMethods();
       storedPaymentMethodsList = storedPaymentMethods.storedPaymentMethods;
     }
 
-    const { sessionData: data, paymentReference } = sessionJson;
+    const { sessionData: data } = sessionJson;
+    let paymentReference = '';
 
     if (!data || !data.id) {
       throw new AdyenInitError(
@@ -132,29 +103,19 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
         component: UIElement,
         actions: SubmitActions
       ) => {
+
         try {
           const reqData = {
             ...state.data,
             shopperLocale: adyenLocale,
             channel: "Web",
-            paymentReference,
             ...(this.getStorePaymentDetails()
               ? { storePaymentMethod: true }
               : {}),
           };
 
-          const response = await fetch(
-            this.initOptions.processorUrl + "/payments",
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                "X-Session-Id": this.initOptions.sessionId,
-              },
-              body: JSON.stringify(reqData),
-            }
-          );
-          const data = await response.json();
+          const data = await this.apiClient.createPayment(reqData);
+          paymentReference = data.paymentReference;
           if (data.action) {
             if (
               ["threeDS2", "qrCode"].includes(data.action.type) &&
@@ -187,6 +148,7 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
           actions.resolve({
             resultCode: data.resultCode,
             action: data.action,
+            ...(data.order?.orderData && { order: data.order }),
           });
         } catch (e) {
           this.handleError({ error: e, component, paymentReference });
@@ -200,23 +162,7 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
         actions: AdditionalDetailsActions
       ) => {
         try {
-          const requestData = {
-            ...state.data,
-            paymentReference,
-          };
-          const url = this.initOptions.processorUrl.endsWith("/")
-            ? `${this.initOptions.processorUrl}payments/details`
-            : `${this.initOptions.processorUrl}/payments/details`;
-
-          const response = await fetch(url, {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Session-Id": this.initOptions.sessionId,
-            },
-            body: JSON.stringify(requestData),
-          });
-          const data = await response.json();
+          const data = await this.apiClient.confirmPaymentDetails({ ...state.data, paymentReference });
           if (
             data.resultCode === "Authorised" ||
             data.resultCode === "Pending"
@@ -241,6 +187,38 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
           this.handleError({ error: e, component, paymentReference });
           component.setStatus("ready");
           actions.reject();
+        }
+      },
+      onBalanceCheck: async (resolve, reject, data) => {
+        try {
+          const result = await this.apiClient.checkGiftCardBalance(data);
+          resolve(result);
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      },
+      onOrderRequest: async (resolve, reject) => {
+        try {
+          const order = await this.apiClient.createOrder();
+          orderAmount = order.amount;
+          resolve({
+            orderData: order.orderData,
+            pspReference: order.pspReference ?? '',
+            remainingAmount: order.remainingAmount,
+          });
+        } catch (e) {
+          reject(e instanceof Error ? e : new Error(String(e)));
+        }
+      },
+      onOrderCancel: async (data, actions) => {
+        try {
+          await this.apiClient.cancelOrder({
+            orderData: data.order.orderData,
+            pspReference: data.order.pspReference,
+          });
+          actions.resolve({ amount: orderAmount! });
+        } catch {
+          actions.reject('Failed to cancel gift card order');
         }
       },
       analytics: { enabled: true },
@@ -288,7 +266,7 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
     if (this.initOptions.onError) {
       this.initOptions.onError(opts.error, {
         paymentReference: opts.paymentReference,
-        method: { type: getPaymentMethodType(opts.component?.props?.type) },
+        method: opts.component?.props?.type ? { type: getPaymentMethodType(opts.component.props.type) } : undefined,
       });
     }
   }
@@ -302,7 +280,7 @@ export class AdyenInitWithSessionFlow implements AdyenInit {
       this.initOptions.onComplete({
         isSuccess: opts.isSuccess,
         paymentReference: opts.paymentReference,
-        method: { type: getPaymentMethodType(opts.component?.props?.type) },
+        method: { type: getPaymentMethodType(opts.component.props?.type) },
       });
     }
   }

--- a/enabler/src/payment-enabler/payment-enabler.ts
+++ b/enabler/src/payment-enabler/payment-enabler.ts
@@ -82,15 +82,15 @@ export type CTAmount = {
   fractionDigits: number;
 };
 
-export const getPaymentMethodType = (
-  adyenPaymentMethod: string
-): PaymentMethod | undefined => {
-  for (const enumKey in PaymentMethod) {
-    if (PaymentMethod[enumKey] === adyenPaymentMethod) {
-      return enumKey as PaymentMethod;
-    }
+export const getPaymentMethodType = (adyenPaymentMethod: string | undefined): PaymentMethod => {
+  if (!adyenPaymentMethod) {
+    throw new Error('Adyen payment method type is undefined');
   }
-  return undefined;
+  const entry = Object.entries(PaymentMethod).find(([, value]) => value === adyenPaymentMethod);
+  if (!entry) {
+    throw new Error(`Unknown Adyen payment method type: "${adyenPaymentMethod}"`);
+  }
+  return entry[0] as PaymentMethod;
 };
 
 export type PaymentResult =

--- a/enabler/src/stored/base.ts
+++ b/enabler/src/stored/base.ts
@@ -10,6 +10,7 @@ import {
   BaseOptions,
   StoredPaymentMethodsConfig,
 } from "../payment-enabler/adyen-payment-enabler";
+import { ProcessorApiClient } from '../api/processor-api.client';
 
 type AdyenComponent = Card; // We can add more components as needed
 
@@ -57,6 +58,7 @@ export abstract class DefaultAdyenStoredComponent implements StoredComponent {
   protected paymentComponentConfigOverride: Record<string, any>;
   protected storedPaymentMethodsConfig: StoredPaymentMethodsConfig;
   protected usedCocoStoredPaymentMethod: CocoStoredPaymentMethod;
+  protected apiClient: ProcessorApiClient;
 
   constructor(opts: {
     paymentMethod: PaymentMethod;
@@ -74,6 +76,7 @@ export abstract class DefaultAdyenStoredComponent implements StoredComponent {
     this.processorUrl = opts.processorUrl;
     this.paymentComponentConfigOverride = opts.paymentComponentConfigOverride;
     this.storedPaymentMethodsConfig = opts.storedPaymentMethodsConfig;
+    this.apiClient = new ProcessorApiClient({ processorUrl: opts.processorUrl, sessionId: opts.sessionId });
   }
 
   abstract init(options: { id: string }): void;

--- a/enabler/src/stored/stored-payment-methods/card.ts
+++ b/enabler/src/stored/stored-payment-methods/card.ts
@@ -112,19 +112,6 @@ export class StoredCardComponent extends DefaultAdyenStoredComponent {
   }
 
   async remove() {
-    const url = this.processorUrl.endsWith("/")
-      ? `${this.processorUrl}stored-payment-methods/${this.usedCocoStoredPaymentMethod.id}`
-      : `${this.processorUrl}/stored-payment-methods/${this.usedCocoStoredPaymentMethod.id}`;
-
-    const response = await fetch(url, {
-      method: "DELETE",
-      headers: {
-        "X-Session-Id": this.sessionId,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error("failed for some reason");
-    }
+    await this.apiClient.deleteStoredPaymentMethod(this.usedCocoStoredPaymentMethod.id);
   }
 }

--- a/processor/src/config/config.ts
+++ b/processor/src/config/config.ts
@@ -37,6 +37,7 @@ export const config = {
   allowedOrigins: process.env.ALLOWED_ORIGINS,
   paymentInterface: process.env.ADYEN_STORED_PAYMENT_METHODS_PAYMENT_INTERFACE || 'checkout-adyen',
   adyenStorePaymentMethodDetailsEnabled: process.env.ADYEN_STORE_PAYMENT_METHOD_DETAILS_ENABLED === 'true',
+  adyenOrderExpiryMinutes: parseInt(process.env.ADYEN_ORDER_EXPIRY_MINUTES || '60', 10),
 };
 
 export const getConfig = () => {

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -53,6 +53,19 @@ export const defaultPaymentMethodConfig: PaymentMethodConfig = {
   swish: {
     supportSeparateCapture: false,
   },
+  //  -- Gift cards --
+  givex: {
+    supportSeparateCapture: false,
+  },
+  svs: {
+    supportSeparateCapture: false,
+  },
+  valuelink: {
+    supportSeparateCapture: false,
+  },
+  genericgiftcard: {
+    supportSeparateCapture: false,
+  },
 };
 
 /**

--- a/processor/src/dtos/adyen-payment.dto.ts
+++ b/processor/src/dtos/adyen-payment.dto.ts
@@ -14,6 +14,9 @@ import { PaypalUpdateOrderRequest } from '@adyen/api-library/lib/src/typings/che
 import { PaypalUpdateOrderResponse } from '@adyen/api-library/lib/src/typings/checkout/paypalUpdateOrderResponse';
 import { DeliveryMethod } from '@adyen/api-library/lib/src/typings/checkout/deliveryMethod';
 import { PaymentAmount } from '@commercetools/connect-payments-sdk/dist/commercetools/types/payment.type';
+import { BalanceCheckResponse } from '@adyen/api-library/lib/src/typings/checkout/balanceCheckResponse';
+import { CreateOrderResponse } from '@adyen/api-library/lib/src/typings/checkout/createOrderResponse';
+import { CancelOrderResponse } from '@adyen/api-library/lib/src/typings/checkout/cancelOrderResponse';
 
 export type PaymentMethodsRequestDTO = Omit<PaymentMethodsRequest, 'amount' | 'merchantAccount'>;
 export type PaymentMethodsResponseDTO = PaymentMethodsResponse;
@@ -42,7 +45,6 @@ export type CreateSessionRequestDTO = Omit<
 
 export type CreateSessionResponseDTO = {
   sessionData: CreateCheckoutSessionResponse;
-  paymentReference: string;
 };
 
 export type CreatePaymentRequestDTO = Omit<
@@ -56,13 +58,11 @@ export type CreatePaymentRequestDTO = Omit<
   | 'reference'
   | 'shopperReference'
   | 'recurringProcessingModel'
-> & {
-  paymentReference?: string;
-};
+>;
 
 export type CreatePaymentResponseDTO = Pick<
   PaymentResponse,
-  'action' | 'resultCode' | 'threeDS2ResponseData' | 'threeDS2Result' | 'threeDSPaymentData'
+  'action' | 'resultCode' | 'threeDS2ResponseData' | 'threeDS2Result' | 'threeDSPaymentData' | 'order'
 > & {
   paymentReference: string;
   merchantReturnUrl?: string;
@@ -121,3 +121,18 @@ export type UpdatePayPalExpressPaymentRequestDTO = Pick<PaypalUpdateOrderRequest
 };
 
 export type UpdatePayPalExpressPaymentResponseDTO = PaypalUpdateOrderResponse;
+
+export type GiftCardBalanceRequestDTO = {
+  paymentMethod: Record<string, string>;
+};
+
+export type GiftCardBalanceResponseDTO = BalanceCheckResponse;
+
+export type CreateOrderResponseDTO = CreateOrderResponse;
+
+export type CancelOrderRequestDTO = {
+  orderData: string;
+  pspReference: string;
+};
+
+export type CancelOrderResponseDTO = CancelOrderResponse;

--- a/processor/src/routes/adyen-payment.route.ts
+++ b/processor/src/routes/adyen-payment.route.ts
@@ -23,6 +23,11 @@ import {
   UpdatePayPalExpressPaymentRequestDTO,
   UpdatePayPalExpressPaymentResponseDTO,
   CreateExpressPaymentResponseDTO,
+  GiftCardBalanceRequestDTO,
+  GiftCardBalanceResponseDTO,
+  CreateOrderResponseDTO,
+  CancelOrderRequestDTO,
+  CancelOrderResponseDTO,
 } from '../dtos/adyen-payment.dto';
 import { AdyenPaymentService } from '../services/adyen-payment.service';
 import { HmacAuthHook } from '../libs/fastify/hooks/hmac-auth.hook';
@@ -261,6 +266,42 @@ export const adyenPaymentRoutes = async (
       await opts.paymentService.deleteStoredPaymentMethodViaCart(id);
 
       return reply.status(200).send();
+    },
+  );
+
+  fastify.post<{ Body: GiftCardBalanceRequestDTO; Reply: GiftCardBalanceResponseDTO }>(
+    '/paymentMethods/balance',
+    {
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
+    },
+    async (request, reply) => {
+      const resp = await opts.paymentService.checkGiftCardBalance({
+        data: request.body,
+      });
+
+      return reply.status(200).send(resp);
+    },
+  );
+
+  fastify.post<{ Reply: CreateOrderResponseDTO }>(
+    '/orders',
+    {
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
+    },
+    async (_request, reply) => {
+      const resp = await opts.paymentService.createOrder();
+      return reply.status(200).send(resp);
+    },
+  );
+
+  fastify.post<{ Body: CancelOrderRequestDTO; Reply: CancelOrderResponseDTO }>(
+    '/orders/cancel',
+    {
+      preHandler: [opts.sessionHeaderAuthHook.authenticate()],
+    },
+    async (request, reply) => {
+      const resp = await opts.paymentService.cancelOrder({ data: request.body });
+      return reply.status(200).send(resp);
     },
   );
 

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -529,26 +529,10 @@ export class AdyenPaymentService extends AbstractPaymentService {
   public async processNotification(opts: { data: NotificationRequestDTO }): Promise<void> {
     log.info('Processing notification', { notification: JSON.stringify(opts.data) });
     try {
-      const updateData = await this.notificationConverter.convert(opts);
-      const payment = await this.getPaymentFromNotification(updateData);
+      const updateDataList = await this.notificationConverter.convert(opts);
 
-      for (const tx of updateData.transactions) {
-        const updatedPayment = await this.ctPaymentService.updatePayment({
-          id: payment.id,
-          pspReference: updateData.pspReference,
-          transaction: tx,
-          ...(updateData.paymentMethodInfoCustomField && {
-            paymentMethodInfo: { custom: updateData.paymentMethodInfoCustomField },
-          }),
-        });
-
-        log.info('Payment updated after processing the notification', {
-          paymentId: updatedPayment.id,
-          version: updatedPayment.version,
-          pspReference: updateData.pspReference,
-          paymentMethod: updateData.paymentMethod,
-          transaction: JSON.stringify(tx),
-        });
+      for (const updateData of updateDataList) {
+        await this.applyNotificationUpdate(updateData);
       }
     } catch (e) {
       if (e instanceof UnsupportedNotificationError) {
@@ -1446,6 +1430,27 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * @param data
    * @returns A payment instance
    */
+  private async applyNotificationUpdate(updateData: NotificationUpdatePayment): Promise<void> {
+    const payment = await this.getPaymentFromNotification(updateData);
+    for (const tx of updateData.transactions) {
+      const updatedPayment = await this.ctPaymentService.updatePayment({
+        id: payment.id,
+        pspReference: updateData.pspReference,
+        transaction: tx,
+        ...(updateData.paymentMethodInfoCustomField && {
+          paymentMethodInfo: { custom: updateData.paymentMethodInfoCustomField },
+        }),
+      });
+      log.info('Payment updated after processing the notification', {
+        paymentId: updatedPayment.id,
+        version: updatedPayment.version,
+        pspReference: updateData.pspReference,
+        paymentMethod: updateData.paymentMethod,
+        transaction: JSON.stringify(tx),
+      });
+    }
+  }
+
   private async getPaymentFromNotification(data: NotificationUpdatePayment): Promise<Payment> {
     const interfaceId = data.pspReference;
     let payment!: Payment;
@@ -1514,13 +1519,13 @@ export class AdyenPaymentService extends AbstractPaymentService {
   }
 
   private async processOtherExpressMethods(payload: CreatePaymentRequestDTO): Promise<CreateExpressPaymentResponseDTO> {
-    let ctCart, ctPayment;
+    let ctCart;
     ctCart = await this.ctCartService.getCart({
       id: getCartIdFromContext(),
     });
 
     const amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
-    ctPayment = await this.ctPaymentService.createPayment({
+    const ctPayment = await this.ctPaymentService.createPayment({
       amountPlanned,
       paymentMethodInfo: {
         paymentInterface: getConfig().paymentInterface,

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -35,8 +35,14 @@ import {
   UpdatePayPalExpressPaymentRequestDTO,
   UpdatePayPalExpressPaymentResponseDTO,
   CreateExpressPaymentResponseDTO,
+  GiftCardBalanceRequestDTO,
+  GiftCardBalanceResponseDTO,
+  CancelOrderRequestDTO,
+  CancelOrderResponseDTO,
+  CreateOrderResponseDTO,
 } from '../dtos/adyen-payment.dto';
 import { AdyenApi, isAdyenApiError, wrapAdyenError } from '../clients/adyen.client';
+import { PaymentAmount } from '@commercetools/connect-payments-sdk/dist/commercetools/types/payment.type';
 import {
   getCartIdFromContext,
   getCheckoutTransactionItemIdFromContext,
@@ -68,6 +74,9 @@ import { PaymentDetailsResponse } from '@adyen/api-library/lib/src/typings/check
 import { CancelPaymentConverter } from './converters/cancel-payment.converter';
 import { RefundPaymentConverter } from './converters/refund-payment.converter';
 import { ReversePaymentConverter } from './converters/reverse-payment.converter';
+import { BalanceCheckConverter } from './converters/balance-check.converter';
+import { CreateOrderConverter } from './converters/create-order.converter';
+import { CancelOrderConverter } from './converters/cancel-order.converter';
 import { log } from '../libs/logger';
 import { ApplePayPaymentSessionError, UnsupportedNotificationError } from '../errors/adyen-api.error';
 import { fetch as undiciFetch, Agent, Dispatcher } from 'undici';
@@ -78,7 +87,12 @@ import { PaymentRefundResponse } from '@adyen/api-library/lib/src/typings/checko
 import { getStoredPaymentMethodsConfig } from '../config/stored-payment-methods.config';
 import { StoredPaymentMethod, StoredPaymentMethodsResponse } from '../dtos/stored-payment-methods.dto';
 import { NotificationTokenizationConverter } from './converters/notification-recurring.converter';
-import { convertAdyenCardBrandToCTFormat, convertPaymentMethodToAdyenFormat } from './converters/helper.converter';
+import {
+  buildCheckoutTransactionItemId,
+  convertAdyenCardBrandToCTFormat,
+  convertPaymentMethodToAdyenFormat,
+  isGiftCardSplitPayment,
+} from './converters/helper.converter';
 import { PaypalUpdateOrderRequest } from '@adyen/api-library/lib/src/typings/checkout/paypalUpdateOrderRequest';
 import { randomUUID } from 'node:crypto';
 import { TransactionDraftDTO, TransactionResponseDTO } from '../dtos/operations/transaction.dto';
@@ -106,6 +120,9 @@ export class AdyenPaymentService extends AbstractPaymentService {
   private capturePaymentConverter: CapturePaymentConverter;
   private refundPaymentConverter: RefundPaymentConverter;
   private reversePaymentConverter: ReversePaymentConverter;
+  private balanceCheckConverter: BalanceCheckConverter;
+  private createOrderConverter: CreateOrderConverter;
+  private cancelOrderConverter: CancelOrderConverter;
 
   constructor(opts: AdyenPaymentServiceOptions) {
     super(opts.ctCartService, opts.ctPaymentService, opts.ctOrderService, opts.ctPaymentMethodService);
@@ -119,6 +136,9 @@ export class AdyenPaymentService extends AbstractPaymentService {
     this.cancelPaymentConverter = new CancelPaymentConverter();
     this.capturePaymentConverter = new CapturePaymentConverter(this.ctCartService, this.ctOrderService);
     this.refundPaymentConverter = new RefundPaymentConverter();
+    this.balanceCheckConverter = new BalanceCheckConverter();
+    this.createOrderConverter = new CreateOrderConverter(this.ctCartService);
+    this.cancelOrderConverter = new CancelOrderConverter();
     this.reversePaymentConverter = new ReversePaymentConverter();
   }
 
@@ -286,48 +306,19 @@ export class AdyenPaymentService extends AbstractPaymentService {
   }
 
   async createSession(opts: { data: CreateSessionRequestDTO }): Promise<CreateSessionResponseDTO> {
-    const ctCart = await this.ctCartService.getCart({
-      id: getCartIdFromContext(),
-    });
-
+    const ctCart = await this.ctCartService.getCart({ id: getCartIdFromContext() });
     const amountPlanned = await this.ctCartService.getPlannedPaymentAmount({ cart: ctCart });
-    const ctPayment = await this.ctPaymentService.createPayment({
-      amountPlanned,
-      paymentMethodInfo: {
-        paymentInterface: getConfig().paymentInterface,
-      },
-      checkoutTransactionItemId: getCheckoutTransactionItemIdFromContext(),
-      ...(ctCart.customerId && {
-        customer: {
-          typeId: 'customer',
-          id: ctCart.customerId,
-        },
-      }),
-      ...(!ctCart.customerId &&
-        ctCart.anonymousId && {
-          anonymousId: ctCart.anonymousId,
-        }),
-    });
-
-    const updatedCart = await this.ctCartService.addPayment({
-      resource: {
-        id: ctCart.id,
-        version: ctCart.version,
-      },
-      paymentId: ctPayment.id,
-    });
 
     const adyenRequestData = this.createSessionConverter.convertRequest({
       data: opts.data,
-      cart: updatedCart,
-      payment: ctPayment,
+      cart: ctCart,
+      amountPlanned,
     });
 
     try {
       const res = await AdyenApi().PaymentsApi.sessions(adyenRequestData);
       return {
         sessionData: this.createSessionConverter.convertResponse({ response: res }),
-        paymentReference: ctPayment.id,
       };
     } catch (e) {
       throw wrapAdyenError(e);
@@ -335,57 +326,33 @@ export class AdyenPaymentService extends AbstractPaymentService {
   }
 
   public async createPayment(opts: { data: CreatePaymentRequestDTO }): Promise<CreatePaymentResponseDTO> {
-    let ctCart, ctPayment;
-    ctCart = await this.ctCartService.getCart({
-      id: getCartIdFromContext(),
+    const ctCart = await this.ctCartService.getCart({ id: getCartIdFromContext() });
+    const isSplitPayment = isGiftCardSplitPayment(opts.data);
+    const amountPlanned = await this.getAmountToPay({
+      isSplitPayment,
+      paymentMethod: opts.data.paymentMethod as Record<string, string>,
+      cart: ctCart,
     });
 
-    if (opts.data.paymentReference) {
-      ctPayment = await this.ctPaymentService.updatePayment({
-        id: opts.data.paymentReference,
-        paymentMethod: opts.data.paymentMethod?.type,
-      });
+    const ctPayment = await this.ctPaymentService.createPayment({
+      amountPlanned,
+      paymentMethodInfo: {
+        paymentInterface: getConfig().paymentInterface,
+        method: opts.data.paymentMethod?.type,
+      },
+      checkoutTransactionItemId: buildCheckoutTransactionItemId(opts.data),
+      ...(ctCart.customerId && { customer: { typeId: 'customer', id: ctCart.customerId } }),
+      ...(!ctCart.customerId && ctCart.anonymousId && { anonymousId: ctCart.anonymousId }),
+    });
 
-      if (await this.hasPaymentAmountChanged(ctCart, ctPayment)) {
-        throw new ErrorInvalidOperation('The payment amount does not fulfill the remaining amount of the cart', {
-          fields: {
-            cartId: ctCart.id,
-            paymentId: ctPayment.id,
-          },
-        });
-      }
-    } else {
-      const amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
-      ctPayment = await this.ctPaymentService.createPayment({
-        amountPlanned,
-        paymentMethodInfo: {
-          paymentInterface: getConfig().paymentInterface,
-          method: opts.data.paymentMethod?.type,
-        },
-        checkoutTransactionItemId: getCheckoutTransactionItemIdFromContext(),
-        ...(ctCart.customerId && {
-          customer: {
-            typeId: 'customer',
-            id: ctCart.customerId,
-          },
-        }),
-        ...(!ctCart.customerId &&
-          ctCart.anonymousId && {
-            anonymousId: ctCart.anonymousId,
-          }),
-      });
+    const updatedCart = await this.ctCartService.addPayment({
+      resource: { id: ctCart.id, version: ctCart.version },
+      paymentId: ctPayment.id,
+    });
 
-      ctCart = await this.ctCartService.addPayment({
-        resource: {
-          id: ctCart.id,
-          version: ctCart.version,
-        },
-        paymentId: ctPayment.id,
-      });
-    }
     const data = await this.createPaymentConverter.convertRequest({
       data: opts.data,
-      cart: ctCart,
+      cart: updatedCart,
       payment: ctPayment,
     });
 
@@ -1392,6 +1359,45 @@ export class AdyenPaymentService extends AbstractPaymentService {
     }
   }
 
+  async checkGiftCardBalance(opts: { data: GiftCardBalanceRequestDTO }): Promise<GiftCardBalanceResponseDTO> {
+    const ctCart = await this.ctCartService.getCart({ id: getCartIdFromContext() });
+    const amountPlanned = await this.ctCartService.getPlannedPaymentAmount({ cart: ctCart });
+
+    log.info('Checking gift card balance.', { paymentMethodType: opts.data.paymentMethod.type });
+    const response = await this.fetchGiftCardBalance({ paymentMethod: opts.data.paymentMethod, amountPlanned });
+    log.info('Gift card balance check completed.', { resultCode: response.resultCode });
+    return response;
+  }
+
+  async createOrder(): Promise<CreateOrderResponseDTO> {
+    const ctCart = await this.ctCartService.getCart({ id: getCartIdFromContext() });
+
+    const request = await this.createOrderConverter.convertRequest({ cart: ctCart });
+
+    log.info('Creating Adyen order for multi payments', { cartId: ctCart.id });
+
+    try {
+      const response = await AdyenApi().OrdersApi.orders(request);
+      log.info('Adyen order created for multi payments', { pspReference: response.pspReference });
+      return response;
+    } catch (e) {
+      throw wrapAdyenError(e);
+    }
+  }
+
+  async cancelOrder(opts: { data: CancelOrderRequestDTO }): Promise<CancelOrderResponseDTO> {
+    const request = this.cancelOrderConverter.convertRequest({ data: opts.data });
+
+    log.info('Cancelling Adyen order.', { pspReference: opts.data.pspReference });
+    try {
+      const response = await AdyenApi().OrdersApi.cancelOrder(request);
+      log.info('Adyen order cancelled.', { pspReference: response.pspReference });
+      return response;
+    } catch (e) {
+      throw wrapAdyenError(e);
+    }
+  }
+
   private convertAdyenResultCode(
     resultCode: PaymentResponse.ResultCodeEnum,
     isActionRequired: boolean,
@@ -1417,14 +1423,6 @@ export class AdyenPaymentService extends AbstractPaymentService {
 
   private isActionRequired(data: PaymentResponse): boolean {
     return data.action?.type !== undefined;
-  }
-
-  private async hasPaymentAmountChanged(cart: Cart, ctPayment: Payment): Promise<boolean> {
-    const amountPlanned = await this.ctCartService.getPaymentAmount({ cart });
-    return (
-      ctPayment.amountPlanned.centAmount !== amountPlanned.centAmount ||
-      ctPayment.amountPlanned.currencyCode !== amountPlanned.currencyCode
-    );
   }
 
   private buildRedirectMerchantUrl(
@@ -1521,49 +1519,33 @@ export class AdyenPaymentService extends AbstractPaymentService {
       id: getCartIdFromContext(),
     });
 
-    if (payload.paymentReference) {
-      ctPayment = await this.ctPaymentService.updatePayment({
-        id: payload.paymentReference,
-        paymentMethod: payload.paymentMethod?.type,
-      });
-
-      if (await this.hasPaymentAmountChanged(ctCart, ctPayment)) {
-        throw new ErrorInvalidOperation('The payment amount does not fulfill the remaining amount of the cart', {
-          fields: {
-            cartId: ctCart.id,
-            paymentId: ctPayment.id,
-          },
-        });
-      }
-    } else {
-      const amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
-      ctPayment = await this.ctPaymentService.createPayment({
-        amountPlanned,
-        paymentMethodInfo: {
-          paymentInterface: getConfig().paymentInterface,
-          method: payload.paymentMethod?.type,
+    const amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
+    ctPayment = await this.ctPaymentService.createPayment({
+      amountPlanned,
+      paymentMethodInfo: {
+        paymentInterface: getConfig().paymentInterface,
+        method: payload.paymentMethod?.type,
+      },
+      checkoutTransactionItemId: getCheckoutTransactionItemIdFromContext(),
+      ...(ctCart.customerId && {
+        customer: {
+          typeId: 'customer',
+          id: ctCart.customerId,
         },
-        checkoutTransactionItemId: getCheckoutTransactionItemIdFromContext(),
-        ...(ctCart.customerId && {
-          customer: {
-            typeId: 'customer',
-            id: ctCart.customerId,
-          },
+      }),
+      ...(!ctCart.customerId &&
+        ctCart.anonymousId && {
+          anonymousId: ctCart.anonymousId,
         }),
-        ...(!ctCart.customerId &&
-          ctCart.anonymousId && {
-            anonymousId: ctCart.anonymousId,
-          }),
-      });
+    });
 
-      ctCart = await this.ctCartService.addPayment({
-        resource: {
-          id: ctCart.id,
-          version: ctCart.version,
-        },
-        paymentId: ctPayment.id,
-      });
-    }
+    ctCart = await this.ctCartService.addPayment({
+      resource: {
+        id: ctCart.id,
+        version: ctCart.version,
+      },
+      paymentId: ctPayment.id,
+    });
 
     const data = await this.createPaymentConverter.convertExpressRequest({
       data: payload,
@@ -1609,5 +1591,44 @@ export class AdyenPaymentService extends AbstractPaymentService {
         ? { merchantReturnUrl: this.buildRedirectMerchantUrl(updatedPayment.id, res.resultCode) }
         : {}),
     } as CreatePaymentResponseDTO;
+  }
+
+  private async getAmountToPay(opts: {
+    isSplitPayment: boolean;
+    paymentMethod: Record<string, string>;
+    cart: Cart;
+  }): Promise<PaymentAmount> {
+    const cartAmount = await this.ctCartService.getPaymentAmount({ cart: opts.cart });
+
+    if (opts.isSplitPayment) {
+      const balanceResponse = await this.fetchGiftCardBalance({
+        paymentMethod: opts.paymentMethod,
+        amountPlanned: cartAmount,
+      });
+      if (balanceResponse.balance) {
+        return {
+          centAmount: balanceResponse.balance.value,
+          currencyCode: balanceResponse.balance.currency,
+          fractionDigits: cartAmount.fractionDigits,
+        };
+      }
+    }
+
+    return cartAmount;
+  }
+
+  private async fetchGiftCardBalance(opts: {
+    paymentMethod: Record<string, string>;
+    amountPlanned: { centAmount: number; currencyCode: string };
+  }): Promise<GiftCardBalanceResponseDTO> {
+    const request = this.balanceCheckConverter.convertRequest({
+      data: { paymentMethod: opts.paymentMethod },
+      amountPlanned: opts.amountPlanned,
+    });
+    try {
+      return await AdyenApi().OrdersApi.getBalanceOfGiftCard(request);
+    } catch (e) {
+      throw wrapAdyenError(e);
+    }
   }
 }

--- a/processor/src/services/converters/balance-check.converter.ts
+++ b/processor/src/services/converters/balance-check.converter.ts
@@ -1,0 +1,24 @@
+import { BalanceCheckRequest } from '@adyen/api-library/lib/src/typings/checkout/balanceCheckRequest';
+import { CurrencyConverters } from '@commercetools/connect-payments-sdk';
+import { config } from '../../config/config';
+import { GiftCardBalanceRequestDTO } from '../../dtos/adyen-payment.dto';
+import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
+
+type AmountPlanned = { centAmount: number; currencyCode: string };
+
+export class BalanceCheckConverter {
+  public convertRequest(opts: { data: GiftCardBalanceRequestDTO; amountPlanned: AmountPlanned }): BalanceCheckRequest {
+    return {
+      merchantAccount: config.adyenMerchantAccount,
+      amount: {
+        value: CurrencyConverters.convertWithMapping({
+          mapping: CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING,
+          amount: opts.amountPlanned.centAmount,
+          currencyCode: opts.amountPlanned.currencyCode,
+        }),
+        currency: opts.amountPlanned.currencyCode,
+      },
+      paymentMethod: opts.data.paymentMethod,
+    };
+  }
+}

--- a/processor/src/services/converters/cancel-order.converter.ts
+++ b/processor/src/services/converters/cancel-order.converter.ts
@@ -1,0 +1,15 @@
+import { CancelOrderRequest } from '@adyen/api-library/lib/src/typings/checkout/cancelOrderRequest';
+import { config } from '../../config/config';
+import { CancelOrderRequestDTO } from '../../dtos/adyen-payment.dto';
+
+export class CancelOrderConverter {
+  public convertRequest(opts: { data: CancelOrderRequestDTO }): CancelOrderRequest {
+    return {
+      merchantAccount: config.adyenMerchantAccount,
+      order: {
+        orderData: opts.data.orderData,
+        pspReference: opts.data.pspReference,
+      },
+    };
+  }
+}

--- a/processor/src/services/converters/create-order.converter.ts
+++ b/processor/src/services/converters/create-order.converter.ts
@@ -23,6 +23,9 @@ export class CreateOrderConverter {
         currency: amountPlanned.currencyCode,
       },
       reference: opts.cart.id,
+      // Configurable expiry window for split payments (ADYEN_ORDER_EXPIRY_MINUTES, default 60).
+      // When the order expires Adyen sends an ORDER_CLOSED webhook which we use to clean up the CT payment.
+      expiresAt: new Date(Date.now() + config.adyenOrderExpiryMinutes * 60 * 1000).toISOString(),
     };
   }
 }

--- a/processor/src/services/converters/create-order.converter.ts
+++ b/processor/src/services/converters/create-order.converter.ts
@@ -1,0 +1,28 @@
+import { CreateOrderRequest } from '@adyen/api-library/lib/src/typings/checkout/createOrderRequest';
+import { Cart, CommercetoolsCartService, CurrencyConverters } from '@commercetools/connect-payments-sdk';
+import { config } from '../../config/config';
+import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
+
+export class CreateOrderConverter {
+  private ctCartService: CommercetoolsCartService;
+
+  constructor(ctCartService: CommercetoolsCartService) {
+    this.ctCartService = ctCartService;
+  }
+
+  public async convertRequest(opts: { cart: Cart }): Promise<CreateOrderRequest> {
+    const amountPlanned = await this.ctCartService.getPlannedPaymentAmount({ cart: opts.cart });
+    return {
+      merchantAccount: config.adyenMerchantAccount,
+      amount: {
+        value: CurrencyConverters.convertWithMapping({
+          mapping: CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING,
+          amount: amountPlanned.centAmount,
+          currencyCode: amountPlanned.currencyCode,
+        }),
+        currency: amountPlanned.currencyCode,
+      },
+      reference: opts.cart.id,
+    };
+  }
+}

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -152,7 +152,6 @@ export class CreatePaymentConverter {
     cart: Cart;
     payment: ExpressPayment;
   }): Promise<PaymentRequest> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const requestData = opts.data;
     const futureOrderNumber = getFutureOrderNumberFromContext();
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -48,8 +48,7 @@ export class CreatePaymentConverter {
     cart: Cart;
     payment: Payment;
   }): Promise<PaymentRequest> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { paymentReference: _, ...requestData } = opts.data;
+    const requestData = opts.data;
     const futureOrderNumber = getFutureOrderNumberFromContext();
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();
@@ -154,7 +153,7 @@ export class CreatePaymentConverter {
     payment: ExpressPayment;
   }): Promise<PaymentRequest> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { paymentReference: _, ...requestData } = opts.data;
+    const requestData = opts.data;
     const futureOrderNumber = getFutureOrderNumberFromContext();
     const deliveryAddress = paymentSDK.ctCartService.getOneShippingAddress({ cart: opts.cart });
     const shopperStatement = getShopperStatement();

--- a/processor/src/services/converters/create-session.converter.ts
+++ b/processor/src/services/converters/create-session.converter.ts
@@ -11,7 +11,7 @@ import {
   extractShopperName,
 } from './helper.converter';
 import { CreateSessionRequestDTO } from '../../dtos/adyen-payment.dto';
-import { Cart, CurrencyConverters, Payment } from '@commercetools/connect-payments-sdk';
+import { Cart, CurrencyConverters } from '@commercetools/connect-payments-sdk';
 import { getFutureOrderNumberFromContext } from '../../libs/fastify/context/context';
 import { paymentSDK } from '../../payment-sdk';
 import { CURRENCIES_FROM_ADYEN_TO_ISO_MAPPING, CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../../constants/currencies';
@@ -22,7 +22,7 @@ export class CreateSessionConverter {
   public convertRequest(opts: {
     data: CreateSessionRequestDTO;
     cart: Cart;
-    payment: Payment;
+    amountPlanned: { centAmount: number; currencyCode: string };
   }): CreateCheckoutSessionRequest {
     const allowedPaymentMethods = convertAllowedPaymentMethodsToAdyenFormat();
     const futureOrderNumber = getFutureOrderNumberFromContext();
@@ -35,15 +35,15 @@ export class CreateSessionConverter {
       amount: {
         value: CurrencyConverters.convertWithMapping({
           mapping: CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING,
-          amount: opts.payment.amountPlanned.centAmount,
-          currencyCode: opts.payment.amountPlanned.currencyCode,
+          amount: opts.amountPlanned.centAmount,
+          currencyCode: opts.amountPlanned.currencyCode,
         }),
-        currency: opts.payment.amountPlanned.currencyCode,
+        currency: opts.amountPlanned.currencyCode,
       },
-      reference: opts.payment.id,
+      reference: opts.cart.id,
       merchantAccount: config.adyenMerchantAccount,
       countryCode: getCountryCodeFromCart(opts.cart),
-      returnUrl: buildReturnUrl(opts.payment.id),
+      returnUrl: buildReturnUrl(opts.cart.id),
       channel: opts.data.channel ? opts.data.channel : CreateCheckoutSessionRequest.ChannelEnum.Web,
       ...(allowedPaymentMethods.length > 0 && { allowedPaymentMethods }),
       lineItems: mapCoCoCartItemsToAdyenLineItems(opts.cart),

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -12,6 +12,7 @@ import {
 } from '@commercetools/connect-payments-sdk';
 import {
   getAllowedPaymentMethodsFromContext,
+  getCheckoutTransactionItemIdFromContext,
   getCtSessionIdFromContext,
   getProcessorUrlFromContext,
 } from '../../libs/fastify/context/context';
@@ -455,3 +456,42 @@ export const extractShopperName = (cart: Cart): { firstName: string; lastName: s
     lastName: lastName ?? '',
   };
 };
+
+export function isGiftCardSplitPayment(data: { paymentMethod?: { type?: string }; order?: unknown }): boolean {
+  return data.paymentMethod?.type === 'giftcard' && data.order != null;
+}
+
+/**
+ * Marker appended to checkoutTransactionItemId when a connector processes
+ * multiple CT payments for the same checkout transaction item (e.g. gift card
+ * partial payment + remaining credit card payment).
+ *
+ * All payments in the split share the same base checkoutTransactionItemId;
+ * the marker signals to the checkout platform that more payments may follow
+ * for this item without the connector needing to track any state.
+ */
+const SPLIT_PAYMENT_MARKER = '#split';
+
+/**
+ * Resolves the checkoutTransactionItemId for a CT payment in the context of
+ * the commercetools Checkout (CTC) integration.
+ *
+ * Standard flow:   checkoutTransactionItemId = "uuid"           (no marker)
+ * Split payment:   checkoutTransactionItemId = "uuid#split"     (marker appended)
+ *
+ * All payments in a split share the same base UUID so CTC can associate them
+ * with the same transaction item. The marker is stripped by the checkout before
+ * querying — see the design decision comment on SPLIT_PAYMENT_MARKER above.
+ */
+export function buildCheckoutTransactionItemId(
+  paymentData: { paymentMethod?: { type?: string }; order?: unknown },
+): string | undefined {
+  const baseId = getCheckoutTransactionItemIdFromContext();
+  if (!baseId) return baseId;
+
+  if (isGiftCardSplitPayment(paymentData) || paymentData.order != null) {
+    return `${baseId}${SPLIT_PAYMENT_MARKER}`;
+  }
+
+  return baseId;
+}

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -483,9 +483,10 @@ const SPLIT_PAYMENT_MARKER = '#split';
  * with the same transaction item. The marker is stripped by the checkout before
  * querying — see the design decision comment on SPLIT_PAYMENT_MARKER above.
  */
-export function buildCheckoutTransactionItemId(
-  paymentData: { paymentMethod?: { type?: string }; order?: unknown },
-): string | undefined {
+export function buildCheckoutTransactionItemId(paymentData: {
+  paymentMethod?: { type?: string };
+  order?: unknown;
+}): string | undefined {
   const baseId = getCheckoutTransactionItemIdFromContext();
   if (!baseId) return baseId;
 

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -19,98 +19,118 @@ import { getConfig } from '../../config/config';
 export class NotificationConverter {
   private ctPaymentService: CommercetoolsPaymentService;
 
-  private manageAuthorizationTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Authorization',
-      state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-    ...(item.success === NotificationRequestItem.SuccessEnum.True && !this.isSeparateCaptureSupported(item)
-      ? [
-          {
-            type: 'Charge',
-            state: 'Success',
-            amount: this.populateAmount(item),
-            interactionId: item.pspReference,
-          },
-        ]
-      : []),
-  ];
+  constructor(ctPaymentService: CommercetoolsPaymentService) {
+    this.ctPaymentService = ctPaymentService;
+  }
 
-  private manageExpireTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Authorization',
-      state: 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  public async convert(opts: { data: NotificationRequestDTO }): Promise<NotificationUpdatePayment[]> {
+    const item = opts.data.notificationItems[0].NotificationRequestItem;
+    return this.populatePaymentUpdates(item);
+  }
 
-  private manageOfferClosedTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Authorization',
-      state: 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private buildSingleUpdate(
+    item: NotificationRequestItem,
+    transactions: TransactionData[],
+    paymentMethodInfoCustomField?: CustomFieldsDraft,
+  ): NotificationUpdatePayment[] {
+    return [
+      {
+        merchantReference: item.merchantReference,
+        pspReference: item.originalReference || item.pspReference,
+        paymentMethod: item.paymentMethod,
+        transactions,
+        paymentMethodInfoCustomField,
+      },
+    ];
+  }
 
-  private manageCaptureTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Charge',
-      state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageAuthorizationTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(
+      item,
+      [
+        {
+          type: 'Authorization',
+          state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
+          amount: this.populateAmount(item),
+          interactionId: item.pspReference,
+        },
+        ...(item.success === NotificationRequestItem.SuccessEnum.True && !this.isSeparateCaptureSupported(item)
+          ? [{ type: 'Charge', state: 'Success', amount: this.populateAmount(item), interactionId: item.pspReference }]
+          : []),
+      ],
+      this.convertNotificationItemToCustomType(item),
+    );
 
-  private manageCaptureFailedTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Charge',
-      state: 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageExpireTransactionData = async (item: NotificationRequestItem): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      { type: 'Authorization', state: 'Failure', amount: this.populateAmount(item), interactionId: item.pspReference },
+    ]);
 
-  private manageCancelAuthorizationTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'CancelAuthorization',
-      state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageOfferClosedTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      { type: 'Authorization', state: 'Failure', amount: this.populateAmount(item), interactionId: item.pspReference },
+    ]);
 
-  private manageRefundTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Refund',
-      state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageCaptureTransactionData = async (item: NotificationRequestItem): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      {
+        type: 'Charge',
+        state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
+        amount: this.populateAmount(item),
+        interactionId: item.pspReference,
+      },
+    ]);
 
-  private manageRefundFailedTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Refund',
-      state: 'Failure',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageCaptureFailedTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      { type: 'Charge', state: 'Failure', amount: this.populateAmount(item), interactionId: item.pspReference },
+    ]);
 
-  private manageChargebackTransactionData = async (item: NotificationRequestItem) => [
-    {
-      type: 'Chargeback',
-      state: 'Success',
-      amount: this.populateAmount(item),
-      interactionId: item.pspReference,
-    },
-  ];
+  private manageCancelAuthorizationTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      {
+        type: 'CancelAuthorization',
+        state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
+        amount: this.populateAmount(item),
+        interactionId: item.pspReference,
+      },
+    ]);
 
-  private manageCancelOrRefundTransactionData = async (item: NotificationRequestItem) => {
+  private manageRefundTransactionData = async (item: NotificationRequestItem): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      {
+        type: 'Refund',
+        state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure',
+        amount: this.populateAmount(item),
+        interactionId: item.pspReference,
+      },
+    ]);
+
+  private manageRefundFailedTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      { type: 'Refund', state: 'Failure', amount: this.populateAmount(item), interactionId: item.pspReference },
+    ]);
+
+  private manageChargebackTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> =>
+    this.buildSingleUpdate(item, [
+      { type: 'Chargeback', state: 'Success', amount: this.populateAmount(item), interactionId: item.pspReference },
+    ]);
+
+  private manageCancelOrRefundTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> => {
     const action = item.additionalData?.['modification.action'];
     const interfaceId = item.originalReference || item.pspReference;
     const payment = await this.findPayment(interfaceId, item.merchantReference);
@@ -122,33 +142,83 @@ export class NotificationConverter {
     // we need to fail the initial transaction created and create a new transaction reflecting the operation taken by adyen.
     // If the check is falsey and adyen actually performs a cancel operation, we simply update the cancel transaction we have in coco from 'pending' to 'success | failure' depending
     // on state returned by adyen
-    if (isMismatchedType) {
-      return [
-        {
-          type: existingReverseTransaction?.type || 'CancelAuthorization',
-          state: 'Failure',
-          amount: this.populateAmount(item),
-          interactionId: item.pspReference,
-        },
-        {
-          type: transactionType,
-          state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure ',
-          amount: this.populateAmount(item),
-          interactionId: item.pspReference,
-        },
-      ];
-    }
-    return [
-      {
-        type: transactionType,
-        state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure ',
-        amount: this.populateAmount(item),
-        interactionId: item.pspReference,
-      },
-    ];
+    const transactions = isMismatchedType
+      ? [
+          {
+            type: existingReverseTransaction?.type || 'CancelAuthorization',
+            state: 'Failure',
+            amount: this.populateAmount(item),
+            interactionId: item.pspReference,
+          },
+          {
+            type: transactionType,
+            state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure ',
+            amount: this.populateAmount(item),
+            interactionId: item.pspReference,
+          },
+        ]
+      : [
+          {
+            type: transactionType,
+            state: item.success === NotificationRequestItem.SuccessEnum.True ? 'Success' : 'Failure ',
+            amount: this.populateAmount(item),
+            interactionId: item.pspReference,
+          },
+        ];
+    return this.buildSingleUpdate(item, transactions);
   };
+
+  private manageOrderClosedTransactionData = async (
+    item: NotificationRequestItem,
+  ): Promise<NotificationUpdatePayment[]> => {
+    // success: true — order closed after all payments completed.
+    // Individual AUTHORISATION webhooks already processed each payment. Nothing to do.
+    if (item.success === NotificationRequestItem.SuccessEnum.True) {
+      return [];
+    }
+
+    // success: false — order expired or was cancelled. Adyen automatically refunds gift card partial
+    // payments but does not send individual REFUND webhooks for them. We use ORDER_CLOSED as the
+    // trigger to mark each partial payment as reversed in commercetools.
+    const results: NotificationUpdatePayment[] = [];
+    let n = 1;
+    while (item.additionalData?.[`order-${n}-pspReference`]) {
+      const partialPspReference = item.additionalData[`order-${n}-pspReference`] as string;
+      const payments = await this.ctPaymentService.findPaymentsByInterfaceId({ interfaceId: partialPspReference });
+      const ctPayment = payments[0];
+
+      if (ctPayment) {
+        const hasSuccessfulCharge = ctPayment.transactions.some((tx) => tx.type === 'Charge' && tx.state === 'Success');
+        const transactionType = hasSuccessfulCharge ? 'Refund' : 'CancelAuthorization';
+        const originalTx = ctPayment.transactions.find(
+          (tx) => (tx.type === 'Charge' || tx.type === 'Authorization') && tx.state === 'Success',
+        );
+
+        results.push({
+          merchantReference: item.merchantReference,
+          pspReference: partialPspReference,
+          transactions: [
+            {
+              type: transactionType,
+              state: 'Success',
+              amount: originalTx?.amount ?? this.populateAmount(item),
+              interactionId: item.pspReference,
+            },
+          ],
+        });
+      }
+
+      n++;
+    }
+
+    return results;
+  };
+
   private POPULATE_TRANSACTIONS_MAPPER: Partial<
-    Record<NotificationRequestItem.EventCodeEnum, (item: NotificationRequestItem) => Promise<TransactionData[]>>
+    Record<
+      NotificationRequestItem.EventCodeEnum,
+      (item: NotificationRequestItem) => Promise<NotificationUpdatePayment[]>
+    >
   > = {
     [NotificationRequestItem.EventCodeEnum.Authorisation]: this.manageAuthorizationTransactionData,
     [NotificationRequestItem.EventCodeEnum.Expire]: this.manageExpireTransactionData,
@@ -160,23 +230,8 @@ export class NotificationConverter {
     [NotificationRequestItem.EventCodeEnum.RefundFailed]: this.manageRefundFailedTransactionData,
     [NotificationRequestItem.EventCodeEnum.Chargeback]: this.manageChargebackTransactionData,
     [NotificationRequestItem.EventCodeEnum.CancelOrRefund]: this.manageCancelOrRefundTransactionData,
+    [NotificationRequestItem.EventCodeEnum.OrderClosed]: this.manageOrderClosedTransactionData,
   };
-
-  constructor(ctPaymentService: CommercetoolsPaymentService) {
-    this.ctPaymentService = ctPaymentService;
-  }
-
-  public async convert(opts: { data: NotificationRequestDTO }): Promise<NotificationUpdatePayment> {
-    const item = opts.data.notificationItems[0].NotificationRequestItem;
-
-    return {
-      merchantReference: item.merchantReference,
-      pspReference: item.originalReference || item.pspReference,
-      paymentMethod: item.paymentMethod,
-      transactions: await this.populateTransactions(item),
-      paymentMethodInfoCustomField: this.convertNotificationItemToCustomType(item),
-    };
-  }
 
   private convertNotificationItemToCustomType(item: NotificationRequestItem): CustomFieldsDraft | undefined {
     if (!getConfig().adyenStorePaymentMethodDetailsEnabled) {
@@ -276,7 +331,7 @@ export class NotificationConverter {
     });
   }
 
-  private async populateTransactions(item: NotificationRequestItem): Promise<TransactionData[]> {
+  private async populatePaymentUpdates(item: NotificationRequestItem): Promise<NotificationUpdatePayment[]> {
     const transactionsMapper = this.POPULATE_TRANSACTIONS_MAPPER[item.eventCode];
     if (!transactionsMapper) {
       throw new UnsupportedNotificationError({ notificationEvent: item.eventCode.toString() });

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -674,7 +674,6 @@ describe('adyen-payment.service', () => {
     const adyenPaymentService: AdyenPaymentService = new AdyenPaymentService(opts);
     const result = await adyenPaymentService.createSession(createSessionOpts);
     expect(result.sessionData).toBeDefined();
-    expect(result.paymentReference).toBeDefined();
     expect(result?.sessionData.id).toStrictEqual('12345');
     expect(result?.sessionData.merchantAccount).toStrictEqual('123456');
     expect(result?.sessionData.reference).toStrictEqual('123456');
@@ -682,7 +681,6 @@ describe('adyen-payment.service', () => {
     expect(result?.sessionData?.amount.currency).toStrictEqual('USD');
     expect(result?.sessionData?.amount.value).toStrictEqual(150000);
     expect(result?.sessionData.expiresAt).toStrictEqual(new Date('2024-12-31T00:00:00.000Z'));
-    expect(result.paymentReference).toStrictEqual('123456');
   });
 
   describe('createApplePaySession', () => {

--- a/processor/test/services/converters/notification.converter.spec.ts
+++ b/processor/test/services/converters/notification.converter.spec.ts
@@ -59,22 +59,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Authorization',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a successful ideal payment notification', async () => {
@@ -108,31 +110,33 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Authorization',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-        {
-          type: 'Charge',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+          {
+            type: 'Charge',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a failure ideal payment notification', async () => {
@@ -166,22 +170,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Authorization',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a expired payment notification', async () => {
@@ -219,22 +225,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Authorization',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a successful card capture notification', async () => {
@@ -272,22 +280,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Charge',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a capture notification with success=false', async () => {
@@ -325,22 +335,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Charge',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a failed card capture notification', async () => {
@@ -378,22 +390,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Charge',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a successful card cancellation notification', async () => {
@@ -431,22 +445,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'CancelAuthorization',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'CancelAuthorization',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a failed card cancellation notification', async () => {
@@ -484,22 +500,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'CancelAuthorization',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'CancelAuthorization',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a successful card refund notification', async () => {
@@ -537,22 +555,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Refund',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Refund',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a failed card refund notification', async () => {
@@ -590,22 +610,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Refund',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Refund',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a refund failed notification', async () => {
@@ -643,22 +665,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Refund',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Refund',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a chargeback notification', async () => {
@@ -696,22 +720,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Chargeback',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Chargeback',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert an offer closed notification', async () => {
@@ -749,22 +775,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'Authorization',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 10000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 10000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   test('convert a non supported event notification', async () => {
@@ -847,31 +875,33 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'CancelAuthorization',
-          state: 'Failure',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 1000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'CancelAuthorization',
+            state: 'Failure',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 1000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-        {
-          type: 'Refund',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 1000,
+          {
+            type: 'Refund',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 1000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
   test('convert a cancelORrefund event notification (where modification.action === cancel)', async () => {
     jest
@@ -914,22 +944,24 @@ describe('notification.converter', () => {
     const result = await converter.convert({ data: notification });
 
     // Assert
-    expect(result).toEqual({
-      merchantReference,
-      pspReference,
-      paymentMethod,
-      transactions: [
-        {
-          type: 'CancelAuthorization',
-          state: 'Success',
-          amount: {
-            currencyCode: 'EUR',
-            centAmount: 1000,
+    expect(result).toEqual([
+      {
+        merchantReference,
+        pspReference,
+        paymentMethod,
+        transactions: [
+          {
+            type: 'CancelAuthorization',
+            state: 'Success',
+            amount: {
+              currencyCode: 'EUR',
+              centAmount: 1000,
+            },
+            interactionId: pspReference,
           },
-          interactionId: pspReference,
-        },
-      ],
-    });
+        ],
+      },
+    ]);
   });
 
   describe('store payment method details via custom fields', () => {
@@ -971,7 +1003,7 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result.paymentMethodInfoCustomField).toBeUndefined();
+      expect(result[0].paymentMethodInfoCustomField).toBeUndefined();
     });
 
     test('should not return custom fields if the Notification is not of type Authorisation', async () => {
@@ -1012,7 +1044,7 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result.paymentMethodInfoCustomField).toBeUndefined();
+      expect(result[0].paymentMethodInfoCustomField).toBeUndefined();
     });
 
     test('should not return custom fields if the Notification is not of success attribute is set to false', async () => {
@@ -1053,7 +1085,7 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result.paymentMethodInfoCustomField).toBeUndefined();
+      expect(result[0].paymentMethodInfoCustomField).toBeUndefined();
     });
 
     test('should not return custom fields if the Notification.paymentMethod attribute is undefined', async () => {
@@ -1092,7 +1124,7 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result.paymentMethodInfoCustomField).toBeUndefined();
+      expect(result[0].paymentMethodInfoCustomField).toBeUndefined();
     });
 
     test('should not return custom fields provided Notification.paymentMethod attribute contains a value for which no mapping exists', async () => {
@@ -1133,7 +1165,7 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result.paymentMethodInfoCustomField).toBeUndefined();
+      expect(result[0].paymentMethodInfoCustomField).toBeUndefined();
     });
 
     test('convert a successful card payment notification which includes paymentMethodInfo custom fields', async () => {
@@ -1174,34 +1206,316 @@ describe('notification.converter', () => {
       const result = await converter.convert({ data: notification });
 
       // Assert
-      expect(result).toEqual({
-        merchantReference,
-        pspReference,
-        paymentMethod,
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference,
+          paymentMethod,
+          transactions: [
+            {
+              type: 'Authorization',
+              state: 'Success',
+              amount: {
+                currencyCode: 'EUR',
+                centAmount: 10000,
+              },
+              interactionId: pspReference,
+            },
+          ],
+          paymentMethodInfoCustomField: {
+            fields: {
+              brand: 'Visa',
+              expiryMonth: 12,
+              expiryYear: 2012,
+              lastFour: '7777',
+            },
+            type: {
+              key: 'commercetools-checkout-card-details',
+              typeId: 'type',
+            },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('ORDER_CLOSED event', () => {
+    test('returns [] when success=true (silent ignore)', async () => {
+      // Arrange
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'some-psp',
+                'order-1-paymentAmount': 'EUR 50.00',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.True,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    test('returns Refund when success=false and CT payment has a successful Charge transaction', async () => {
+      // Arrange
+      const mockPaymentWithCharge = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP',
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Success',
+            id: 'tx-1',
+            amount: { centAmount: 5000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([mockPaymentWithCharge] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP',
+                'order-1-paymentAmount': 'EUR 50.00',
+                'order-1-paymentMethod': 'givex',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP',
+          transactions: [
+            {
+              type: 'Refund',
+              state: 'Success',
+              amount: { centAmount: 5000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('returns CancelAuthorization when success=false and CT payment has only Authorization (no Charge)', async () => {
+      // Arrange
+      const mockPaymentWithAuthOnly = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP',
         transactions: [
           {
             type: 'Authorization',
             state: 'Success',
-            amount: {
-              currencyCode: 'EUR',
-              centAmount: 10000,
-            },
-            interactionId: pspReference,
+            id: 'tx-1',
+            amount: { centAmount: 5000, currencyCode: 'EUR' },
           },
         ],
-        paymentMethodInfoCustomField: {
-          fields: {
-            brand: 'Visa',
-            expiryMonth: 12,
-            expiryYear: 2012,
-            lastFour: '7777',
+      };
+
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([mockPaymentWithAuthOnly] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP',
+                'order-1-paymentAmount': 'EUR 50.00',
+                'order-1-paymentMethod': 'givex',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
           },
-          type: {
-            key: 'commercetools-checkout-card-details',
-            typeId: 'type',
-          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP',
+          transactions: [
+            {
+              type: 'CancelAuthorization',
+              state: 'Success',
+              amount: { centAmount: 5000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
         },
-      });
+      ]);
+    });
+
+    test('returns [] when success=false but CT payment is not found', async () => {
+      // Arrange
+      jest.spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId').mockResolvedValue([]);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'UNKNOWN_PSP',
+                'order-1-paymentAmount': 'EUR 50.00',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert
+      expect(result).toEqual([]);
+    });
+
+    test('returns multiple NotificationUpdatePayment objects for multiple partial payments', async () => {
+      // Arrange
+      const mockPaymentWithCharge = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP_1',
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Success',
+            id: 'tx-1',
+            amount: { centAmount: 3000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+      const mockPaymentWithAuthOnly = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP_2',
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Success',
+            id: 'tx-2',
+            amount: { centAmount: 2000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValueOnce([mockPaymentWithCharge] as any)
+        .mockResolvedValueOnce([mockPaymentWithAuthOnly] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP_1',
+                'order-1-paymentAmount': 'EUR 30.00',
+                'order-1-paymentMethod': 'givex',
+                'order-2-pspReference': 'GIFT_CARD_PSP_2',
+                'order-2-paymentAmount': 'EUR 20.00',
+                'order-2-paymentMethod': 'givex',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP_1',
+          transactions: [
+            {
+              type: 'Refund',
+              state: 'Success',
+              amount: { centAmount: 3000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP_2',
+          transactions: [
+            {
+              type: 'CancelAuthorization',
+              state: 'Success',
+              amount: { centAmount: 2000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3934

**Add gift card split payment support to the Adyen dropin**

Implements the Adyen partial payment flow that allows shoppers to pay with a gift card for part of the order total and complete the remainder with another payment method for **dropin component**.

Enabler
- onOrderRequest / onOrderCancel callbacks to create and cancel Adyen Orders
- Passes order and remainingAmount back so the dropin renders the deducted balance UI
- Skips onPayButtonClick on the gift card re-submit after order creation

Processor
- New endpoints: POST /orders and POST /orders/cancel
- CT payments are now always created at payment time (not at session creation)
- Gift card payment amount is taken from the balance check, not the full cart total
- #split marker on checkoutTransactionItemId groups CT payments belonging to the same split
- ORDER_CLOSED webhook handler reverses partial payments when the order expires or is cancelled
- ADYEN_ORDER_EXPIRY_MINUTES env var to configure order expiry window (default: 60 min)