### PR TITLE
feat: add optional logging of Adyen request/response as payment interface interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
       - [Solution](#solution)
       - [Configuration](#configuration)
       - [Behavior](#behavior)
+    - [Interface interaction logging](#interface-interaction-logging)
+      - [Covered operations](#covered-operations)
+      - [Sensitive field masking](#sensitive-field-masking)
+      - [Configuration](#configuration-1)
   - [Development](#development)
     - [Configuration steps](#configuration-steps)
       - [1. Environment Variable Setup](#1-environment-variable-setup)
@@ -431,6 +435,52 @@ By default, Bancontact (`bcmc` and `bcmc_mobile`) uses immediate capture. Howeve
 
 - **If `supportSeparateCapture` is `false`**: The connector automatically creates a `Charge` transaction upon receiving the authorization confirmation, immediately synchronizing the payment state with Adyen's immediate capture.
 - **If `supportSeparateCapture` is `true`**: The connector waits for the `CAPTURE` webhook from Adyen before creating the `Charge` transaction, supporting manual/deferred capture workflows.
+
+### Interface interaction logging
+
+When enabled, the connector stores every request/response exchanged with Adyen as a `payment-interface-interaction` custom field on the commercetools `Payment` resource. This is useful for debugging payment flows or for extracting information that the connector does not explicitly persist.
+
+#### Covered operations
+
+The following operations are recorded:
+
+| Operation | Interaction type stored |
+|---|---|
+| Create payment | `CreatePayment` |
+| Confirm payment (additional details) | `ConfirmPayment` |
+| Capture | `CapturePayment` |
+| Refund | `RefundPayment` |
+| Cancel | `CancelPayment` |
+| Reverse | `ReversePayment` |
+| Incoming Adyen notification | `Notification` |
+
+Each interaction records the full request and response .
+
+#### Sensitive field masking
+
+Before storing any payload, the connector automatically masks sensitive data to avoid persisting PCI or PII information:
+
+- **`paymentMethod` block**: every sub-field except `type` is replaced with `***`. This covers encrypted card fields (`encryptedCardNumber`, `encryptedSecurityCode`, etc.), raw card numbers, Apple Pay tokens, Google Pay tokens, and any other payment-method-specific data regardless of field name.
+- **Named fields at any nesting depth**: the following field names are masked wherever they appear in the payload, including inside `additionalData` dotted keys (e.g. `"tokenization.storedPaymentMethodId"`):
+
+  | Field | Category |
+  |---|---|
+  | `shopperEmail` | PII |
+  | `shopperIP` | PII |
+  | `holderName` | PII |
+  | `storedPaymentMethodId` | PII |
+  | `riskData` | Opaque SDK blob |
+  | `sdkData` | Opaque SDK blob |
+  | `checkoutAttemptId` | Opaque SDK blob |
+  | `clientData` | Opaque SDK blob |
+
+All other fields (amounts, references, result codes, event codes, merchant account, etc.) are stored as-is.
+
+#### Configuration
+
+Set the environment variable `ADYEN_SAVE_INTERFACE_INTERACTIONS` to `"true"`. The default value is `"false"` (disabled).
+
+When enabled, the required commercetools custom type (`commercetools-checkout-payment-interface-interaction`) is created automatically on connector deploy, no manual setup is needed.
 
 ## Development
 

--- a/connect.yaml
+++ b/connect.yaml
@@ -93,6 +93,9 @@ deployAs:
         - key: ADYEN_PARTIAL_PAYMENTS_ENABLED
           description: If set to "true" then partial payments (split payments using Adyen Orders API, e.g. gift cards) are enabled. When enabled, the connector creates the required custom type to store Adyen Order data on CT payments. Only supported with the Drop-in component. Default value is "false".
           required: false
+        - key: ADYEN_SAVE_INTERFACE_INTERACTIONS
+          description: If set to "true" then every request/response exchanged with Adyen (and incoming notifications) is stored as an interface interaction on the commercetools Payment. Sensitive fields are automatically masked. Default value is "false".
+          required: false
 
       securedConfiguration:
         - key: CTP_CLIENT_SECRET

--- a/processor/src/config/config.ts
+++ b/processor/src/config/config.ts
@@ -45,6 +45,9 @@ export const config = {
   // Adyen — partial payments (gift cards)
   adyenPartialPaymentsEnabled: process.env.ADYEN_PARTIAL_PAYMENTS_ENABLED === 'true',
   adyenOrderExpiryMinutes: parseInt(process.env.ADYEN_ORDER_EXPIRY_MINUTES || '60', 10),
+
+  // Interface interactions
+  saveInterfaceInteractions: process.env.ADYEN_SAVE_INTERFACE_INTERACTIONS === 'true',
 };
 
 export const getConfig = () => {

--- a/processor/src/config/payment-method.config.ts
+++ b/processor/src/config/payment-method.config.ts
@@ -100,6 +100,7 @@ export const defaultPaymentMethodConfig: PaymentMethodConfig = {
   molpay_ebanking_fpx_MY: { supportSeparateCapture: false },
   ideal: { supportSeparateCapture: false },
   wechatpayQR: { supportSeparateCapture: false },
+  ...giftCardConfig,
 };
 
 /**

--- a/processor/src/connectors/actions.ts
+++ b/processor/src/connectors/actions.ts
@@ -5,6 +5,20 @@ import { GiftCardDetailsTypeDraft } from '../custom-types/gift-card-details';
 import { AdyenOrderDetailsTypeDraft } from '../custom-types/adyen-order-details';
 
 export async function createCheckoutCustomType(): Promise<void> {
+  if (getConfig().saveInterfaceInteractions) {
+    log.info('Creating interface interaction custom type if not existing...');
+    try {
+      const interfaceInteractionType =
+        await paymentSDK.ctCustomTypeService.createOrUpdatePredefinedInterfaceInteractionType();
+      log.info('Created (if not existing) interface interaction custom type', {
+        typeId: interfaceInteractionType.id,
+        typeKey: interfaceInteractionType.key,
+      });
+    } catch (error) {
+      log.error('Error creating interface interaction custom type', { error });
+    }
+  }
+
   if (getConfig().adyenPartialPaymentsEnabled) {
     log.info('Creating Adyen order details custom type if not existing...');
     try {

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -93,6 +93,7 @@ import {
   convertPaymentMethodToAdyenFormat,
   isGiftCardSplitPayment,
 } from './converters/helper.converter';
+import { populateInterfaceInteraction, AdyenRequestPayload, AdyenResponsePayload } from './helper.service';
 import {
   AdyenOrderDetailsTypeDraft,
   AdyenOrderDetailsTypeKey,
@@ -105,6 +106,13 @@ import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../constants/currencies';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJSON = require('../../package.json');
+
+const MODIFICATION_TYPE_MAP = {
+  capture: 'CapturePayment',
+  refund: 'RefundPayment',
+  cancel: 'CancelPayment',
+  reverse: 'ReversePayment',
+} as const;
 
 export type AdyenPaymentServiceOptions = {
   ctCartService: CommercetoolsCartService;
@@ -443,6 +451,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
         ? await this.buildAdyenOrderCustomFields(ctPayment, res.order)
         : {};
 
+    const interfaceInteraction = this.buildInterfaceInteraction('CreatePayment', data, res);
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
       pspReference: res.pspReference,
@@ -458,6 +468,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
           paymentMethodInfo: { token: { value: data.paymentMethod.storedPaymentMethodId } },
         }),
       ...orderCustomFields,
+      pspInteractions: interfaceInteraction,
     });
 
     log.info(`Payment authorization processed.`, {
@@ -492,6 +503,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       throw wrapAdyenError(e);
     }
 
+    const interfaceInteraction = this.buildInterfaceInteraction('ConfirmPayment', data, res);
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
       pspReference: res.pspReference,
@@ -502,6 +515,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         interfaceId: res.pspReference,
         state: this.convertAdyenResultCode(res.resultCode as PaymentResponse.ResultCodeEnum, false),
       },
+      pspInteractions: interfaceInteraction,
     });
 
     log.info(`Payment confirmation processed.`, {
@@ -572,6 +586,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       throw wrapAdyenError(e);
     }
 
+    const interfaceInteraction = this.buildInterfaceInteraction('ConfirmPayment', data, res);
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
       pspReference: res.pspReference,
@@ -585,6 +601,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         interfaceId: res.pspReference,
         state: this.convertAdyenResultCode(res.resultCode as PaymentResponse.ResultCodeEnum, false),
       },
+      pspInteractions: interfaceInteraction,
     });
 
     log.info(`Payment confirmation processed.`, {
@@ -608,7 +625,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       const updateDataList = await this.notificationConverter.convert(opts);
 
       for (const updateData of updateDataList) {
-        await this.applyNotificationUpdate(updateData);
+        await this.applyNotificationUpdate(updateData, opts.data);
       }
     } catch (e) {
       if (e instanceof UnsupportedNotificationError) {
@@ -933,6 +950,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       this.isActionRequired(res),
     );
 
+    const interfaceInteraction = this.buildInterfaceInteraction('CreatePayment', data, res);
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: newlyCreatedPayment.id,
       pspReference: res.pspReference,
@@ -943,6 +962,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         interactionId: res.pspReference, // Deprecated but kept for backward compatibility
         interfaceId: res.pspReference,
       },
+      pspInteractions: interfaceInteraction,
     });
 
     log.info("Payment authorization processed for 'transaction' stored payment method", {
@@ -1293,52 +1313,61 @@ export class AdyenPaymentService extends AbstractPaymentService {
 
     const interfaceId = request.payment.interfaceId as string;
 
-    const response = await this.makeCallToAdyenInternal(interfaceId, adyenOperation, request);
+    const { adyenRequest, adyenResponse } = await this.makeCallToAdyenInternal(interfaceId, adyenOperation, request);
+
+    const interfaceInteraction = this.buildInterfaceInteraction(
+      MODIFICATION_TYPE_MAP[adyenOperation],
+      adyenRequest,
+      adyenResponse,
+    );
 
     await this.ctPaymentService.updatePayment({
       id: request.payment.id,
       transaction: {
         type: transactionType,
         amount,
-        interactionId: response.pspReference, // Deprecated but kept for backward compatibility
-        interfaceId: response.pspReference,
+        interactionId: adyenResponse.pspReference, // Deprecated but kept for backward compatibility
+        interfaceId: adyenResponse.pspReference,
         state: this.convertPaymentModificationOutcomeToState(PaymentModificationStatus.RECEIVED),
       },
+      pspInteractions: interfaceInteraction,
     });
 
-    return { outcome: PaymentModificationStatus.RECEIVED, pspReference: response.pspReference };
+    return { outcome: PaymentModificationStatus.RECEIVED, pspReference: adyenResponse.pspReference };
   }
 
   private async makeCallToAdyenInternal(
     interfaceId: string,
     adyenOperation: 'capture' | 'refund' | 'cancel' | 'reverse',
     request: CapturePaymentRequest | CancelPaymentRequest | RefundPaymentRequest | ReversePaymentRequest,
-  ): Promise<PaymentCaptureResponse | PaymentCancelResponse | PaymentRefundResponse> {
+  ): Promise<{
+    adyenRequest: AdyenRequestPayload;
+    adyenResponse: PaymentCaptureResponse | PaymentCancelResponse | PaymentRefundResponse;
+  }> {
     try {
       switch (adyenOperation) {
         case 'capture': {
-          return await AdyenApi().ModificationsApi.captureAuthorisedPayment(
-            interfaceId,
-            await this.capturePaymentConverter.convertRequest(request as CapturePaymentRequest),
-          );
+          const adyenRequest = await this.capturePaymentConverter.convertRequest(request as CapturePaymentRequest);
+          const adyenResponse = await AdyenApi().ModificationsApi.captureAuthorisedPayment(interfaceId, adyenRequest);
+          return { adyenRequest, adyenResponse };
         }
         case 'refund': {
-          return await AdyenApi().ModificationsApi.refundCapturedPayment(
-            interfaceId,
-            this.refundPaymentConverter.convertRequest(request as RefundPaymentRequest),
-          );
+          const adyenRequest = this.refundPaymentConverter.convertRequest(request as RefundPaymentRequest);
+          const adyenResponse = await AdyenApi().ModificationsApi.refundCapturedPayment(interfaceId, adyenRequest);
+          return { adyenRequest, adyenResponse };
         }
         case 'cancel': {
-          return await AdyenApi().ModificationsApi.cancelAuthorisedPaymentByPspReference(
+          const adyenRequest = this.cancelPaymentConverter.convertRequest(request as CancelPaymentRequest);
+          const adyenResponse = await AdyenApi().ModificationsApi.cancelAuthorisedPaymentByPspReference(
             interfaceId,
-            this.cancelPaymentConverter.convertRequest(request as CancelPaymentRequest),
+            adyenRequest,
           );
+          return { adyenRequest, adyenResponse };
         }
         case 'reverse': {
-          return await AdyenApi().ModificationsApi.refundOrCancelPayment(
-            interfaceId,
-            this.reversePaymentConverter.convertRequest(request as ReversePaymentRequest),
-          );
+          const adyenRequest = this.reversePaymentConverter.convertRequest(request as ReversePaymentRequest);
+          const adyenResponse = await AdyenApi().ModificationsApi.refundOrCancelPayment(interfaceId, adyenRequest);
+          return { adyenRequest, adyenResponse };
         }
         default: {
           log.error(`makeCallToAdyenInternal: Operation  ${adyenOperation} not supported when modifying payment.`);
@@ -1525,9 +1554,16 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * @param data
    * @returns A payment instance
    */
-  private async applyNotificationUpdate(updateData: NotificationUpdatePayment): Promise<void> {
+  private async applyNotificationUpdate(
+    updateData: NotificationUpdatePayment,
+    rawNotification?: NotificationRequestDTO,
+  ): Promise<void> {
     const payment = await this.getPaymentFromNotification(updateData);
-    for (const tx of updateData.transactions) {
+    const interfaceInteraction = rawNotification
+      ? this.buildInterfaceInteraction('Notification', rawNotification, undefined)
+      : undefined;
+    for (let i = 0; i < updateData.transactions.length; i++) {
+      const tx = updateData.transactions[i];
       const updatedPayment = await this.ctPaymentService.updatePayment({
         id: payment.id,
         pspReference: updateData.pspReference,
@@ -1535,6 +1571,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         ...(updateData.paymentMethodInfoCustomField && {
           paymentMethodInfo: { custom: updateData.paymentMethodInfoCustomField },
         }),
+        ...(i === 0 && { pspInteractions: interfaceInteraction }),
       });
       log.info('Payment updated after processing the notification', {
         paymentId: updatedPayment.id,
@@ -1665,6 +1702,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       this.isActionRequired(res),
     );
 
+    const interfaceInteraction = this.buildInterfaceInteraction('CreatePayment', data, res);
+
     const updatedPayment = await this.ctPaymentService.updatePayment({
       id: ctPayment.id,
       pspReference: res.pspReference,
@@ -1675,6 +1714,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         interfaceId: res.pspReference,
         state: txState,
       },
+      pspInteractions: interfaceInteraction,
     });
 
     log.info(`Payment authorization processed.`, {
@@ -1730,5 +1770,15 @@ export class AdyenPaymentService extends AbstractPaymentService {
     } catch (e) {
       throw wrapAdyenError(e);
     }
+  }
+
+  private buildInterfaceInteraction(type: string, request: AdyenRequestPayload, response: AdyenResponsePayload | undefined) {
+    return populateInterfaceInteraction({
+      interactionId: randomUUID(),
+      type,
+      createdAt: new Date().toISOString(),
+      request,
+      response,
+    });
   }
 }

--- a/processor/src/services/helper.service.ts
+++ b/processor/src/services/helper.service.ts
@@ -1,0 +1,119 @@
+import { CustomFieldsDraft, GenerateInterfaceInteractionCustomFieldsDraft } from '@commercetools/connect-payments-sdk';
+import { getConfig } from '../config/config';
+import { PaymentRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRequest';
+import { PaymentDetailsRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentDetailsRequest';
+import { PaymentCaptureRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentCaptureRequest';
+import { PaymentRefundRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRefundRequest';
+import { PaymentCancelRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentCancelRequest';
+import { PaymentReversalRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentReversalRequest';
+import { PaymentResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentResponse';
+import { PaymentDetailsResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentDetailsResponse';
+import { PaymentCaptureResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentCaptureResponse';
+import { PaymentRefundResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentRefundResponse';
+import { PaymentCancelResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentCancelResponse';
+import { PaymentReversalResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentReversalResponse';
+import { NotificationRequestDTO } from '../dtos/adyen-payment.dto';
+
+export type AdyenRequestPayload =
+  | PaymentRequest
+  | PaymentDetailsRequest
+  | PaymentCaptureRequest
+  | PaymentRefundRequest
+  | PaymentCancelRequest
+  | PaymentReversalRequest
+  | NotificationRequestDTO;
+
+export type AdyenResponsePayload =
+  | PaymentResponse
+  | PaymentDetailsResponse
+  | PaymentCaptureResponse
+  | PaymentRefundResponse
+  | PaymentCancelResponse
+  | PaymentReversalResponse;
+
+export type InterfaceInteractionData = {
+  interactionId: string;
+  type: string;
+  createdAt: string;
+  request?: AdyenRequestPayload;
+  response?: AdyenResponsePayload;
+};
+
+const MASKED_FIELDS = new Set([
+  // PII — can appear at any depth outside paymentMethod
+  'shopperEmail',
+  'shopperIP',
+  'holderName',
+  'storedPaymentMethodId',
+  // Noise / opaque blobs
+  'riskData',
+  'sdkData',
+  'checkoutAttemptId',
+  'clientData',
+]);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+// Masks every sub-field except `type` since the request paymentMethod block can contain
+// raw card data whose field names vary by payment method (encryptedCardNumber, applePayToken, etc.).
+function maskPaymentMethod(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, k === 'type' ? v : '***']));
+}
+
+// Matches dotted keys used in Adyen's additionalData (e.g. "tokenization.storedPaymentMethodId")
+// by checking each segment against MASKED_FIELDS.
+function shouldMask(key: string): boolean {
+  return MASKED_FIELDS.has(key) || (key.includes('.') && key.split('.').some((segment) => MASKED_FIELDS.has(segment)));
+}
+
+// Recursively walks the payload and replaces sensitive values with '***'.
+// maskPaymentMethodBlock controls whether the paymentMethod object is fully masked — true for
+// requests (which carry raw card data) and false for responses (which only carry brand/type metadata).
+function maskFields(obj: unknown, maskPaymentMethodBlock: boolean): unknown {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => maskFields(item, maskPaymentMethodBlock));
+  }
+  if (isPlainObject(obj)) {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => {
+        if (key === 'paymentMethod' && maskPaymentMethodBlock && isPlainObject(value)) {
+          return [key, maskPaymentMethod(value)];
+        }
+        if (shouldMask(key)) {
+          return [key, '***'];
+        }
+        return [key, maskFields(value, maskPaymentMethodBlock)];
+      }),
+    );
+  }
+  return obj;
+}
+
+export function maskRequest<T extends AdyenRequestPayload>(req: T): T {
+  return maskFields(req, true) as T;
+}
+
+export function maskResponse<T extends AdyenResponsePayload>(res: T): T {
+  return maskFields(res, false) as T;
+}
+
+// Returns a CT CustomFieldsDraft array ready to be appended to `pspInteractions`,
+// or undefined when the feature is disabled (ADYEN_SAVE_INTERFACE_INTERACTIONS != "true").
+// Both request and response are masked before serialization.
+export const populateInterfaceInteraction = (data: InterfaceInteractionData): CustomFieldsDraft[] | undefined => {
+  if (!getConfig().saveInterfaceInteractions) {
+    return undefined;
+  }
+
+  return [
+    GenerateInterfaceInteractionCustomFieldsDraft({
+      interactionId: data.interactionId,
+      type: data.type,
+      createdAt: data.createdAt,
+      request: data.request !== undefined ? JSON.stringify(maskRequest(data.request)) : undefined,
+      response: data.response !== undefined ? JSON.stringify(maskResponse(data.response)) : undefined,
+    }),
+  ];
+};

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -643,6 +643,62 @@ describe('adyen-payment.service', () => {
     expect(result?.paymentReference).toStrictEqual('123456');
   });
 
+  describe('interface interactions', () => {
+    const createPaymentOpts: { data: CreatePaymentRequestDTO } = {
+      data: { paymentMethod: { type: CardDetails.TypeEnum.Scheme } as CardDetails },
+    };
+
+    const setupCreatePaymentMocks = () => {
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(mockGetCartResultShippingModeSimple());
+      jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue(mockGetPaymentAmount);
+      jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(mockGetPaymentResult);
+      jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(mockGetCartResultShippingModeSimple());
+      jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
+      jest.spyOn(FastifyContext, 'getMerchantReturnUrlFromContext').mockReturnValue('http://127.0.0.1/checkout/result');
+      jest.spyOn(PaymentsApi.prototype, 'payments').mockResolvedValue(mockAdyenCreatePaymentResponse);
+      jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(mockGetPaymentResult);
+    };
+
+    test('createPayment passes pspInteractions to updatePayment when saveInterfaceInteractions is enabled', async () => {
+      // Arrange
+      jest
+        .spyOn(Config, 'getConfig')
+        .mockReturnValue({ saveInterfaceInteractions: true, adyenMerchantAccount: 'adyenMerchantAccount' } as any);
+      setupCreatePaymentMocks();
+
+      // Act
+      await new AdyenPaymentService(opts).createPayment(createPaymentOpts);
+
+      // Assert
+      expect(DefaultPaymentService.prototype.updatePayment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pspInteractions: expect.arrayContaining([
+            expect.objectContaining({
+              type: expect.objectContaining({ key: 'commercetools-checkout-payment-interface-interaction' }),
+              fields: expect.objectContaining({ type: 'CreatePayment' }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    test('createPayment does not pass pspInteractions to updatePayment when saveInterfaceInteractions is disabled', async () => {
+      // Arrange
+      jest
+        .spyOn(Config, 'getConfig')
+        .mockReturnValue({ saveInterfaceInteractions: false, adyenMerchantAccount: 'adyenMerchantAccount' } as any);
+      setupCreatePaymentMocks();
+
+      // Act
+      await new AdyenPaymentService(opts).createPayment(createPaymentOpts);
+
+      // Assert
+      expect(DefaultPaymentService.prototype.updatePayment).toHaveBeenCalledWith(
+        expect.objectContaining({ pspInteractions: undefined }),
+      );
+    });
+  });
+
   test('getPaymentMethods', async () => {
     const getPaymentMethodsOpts: { data: PaymentMethodsRequestDTO } = {
       data: {},

--- a/processor/test/services/helper.service.spec.ts
+++ b/processor/test/services/helper.service.spec.ts
@@ -1,0 +1,273 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import * as Config from '../../src/config/config';
+import { populateInterfaceInteraction, maskRequest, maskResponse } from '../../src/services/helper.service';
+import { CardDetails } from '@adyen/api-library/lib/src/typings/checkout/cardDetails';
+import { ApplePayDetails } from '@adyen/api-library/lib/src/typings/checkout/applePayDetails';
+import { PayWithGoogleDetails } from '@adyen/api-library/lib/src/typings/checkout/payWithGoogleDetails';
+import { PaymentRequest } from '@adyen/api-library/lib/src/typings/checkout/paymentRequest';
+import { PaymentResponse } from '@adyen/api-library/lib/src/typings/checkout/paymentResponse';
+import { NotificationRequestItem } from '@adyen/api-library/lib/src/typings/notification/notificationRequestItem';
+import { NotificationRequestDTO } from '../../src/dtos/adyen-payment.dto';
+
+describe('maskRequest', () => {
+  test('encrypted card: masks all paymentMethod fields except type', () => {
+    // Arrange
+    const paymentMethod: CardDetails = {
+      type: CardDetails.TypeEnum.Scheme,
+      encryptedCardNumber: 'test_4111111111111111',
+      encryptedExpiryMonth: 'test_03',
+      encryptedExpiryYear: 'test_2030',
+      encryptedSecurityCode: 'test_737',
+    };
+    const input: PaymentRequest = {
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod,
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YOUR_MERCHANT_ACCOUNT',
+    };
+
+    // Act
+    const result = maskRequest(input);
+
+    // Assert
+    expect(result).toEqual({
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod: {
+        type: CardDetails.TypeEnum.Scheme,
+        encryptedCardNumber: '***',
+        encryptedExpiryMonth: '***',
+        encryptedExpiryYear: '***',
+        encryptedSecurityCode: '***',
+      },
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YOUR_MERCHANT_ACCOUNT',
+    });
+  });
+
+  test('plain card: masks number, cvc and all paymentMethod fields except type', () => {
+    // Arrange
+    const paymentMethod: CardDetails = {
+      type: CardDetails.TypeEnum.Scheme,
+      number: '4111111111111111',
+      holderName: 'John Smith',
+      cvc: '737',
+    };
+    const input: PaymentRequest = {
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod,
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YOUR_MERCHANT_ACCOUNT',
+    };
+
+    // Act
+    const result = maskRequest(input);
+
+    // Assert
+    expect(result).toEqual({
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod: {
+        type: CardDetails.TypeEnum.Scheme,
+        number: '***',
+        holderName: '***',
+        cvc: '***',
+      },
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YOUR_MERCHANT_ACCOUNT',
+    });
+  });
+
+  test('apple pay: token masked via paymentMethod special case', () => {
+    // Arrange
+    const paymentMethod: ApplePayDetails = {
+      type: ApplePayDetails.TypeEnum.Applepay,
+      applePayToken: 'VNRWtuNlNEWkRCSm1xWndjMDFFbktkQU...',
+    };
+    const input: PaymentRequest = {
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod,
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YOUR_MERCHANT_ACCOUNT',
+    };
+
+    // Act
+    const result = maskRequest(input);
+
+    // Assert
+    expect(result).toEqual({
+      ...input,
+      paymentMethod: { type: ApplePayDetails.TypeEnum.Applepay, applePayToken: '***' },
+    });
+  });
+
+  test('google pay: token masked via paymentMethod special case', () => {
+    // Arrange
+    const paymentMethod: PayWithGoogleDetails = {
+      type: PayWithGoogleDetails.TypeEnum.Paywithgoogle,
+      googlePayToken: '==Payload as retrieved from Google Pay response==',
+    };
+    const input: PaymentRequest = {
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'Your order number',
+      paymentMethod,
+      returnUrl: 'https://your-company.example.com/...',
+      merchantAccount: 'YourMerchantAccount',
+    };
+
+    // Act
+    const result = maskRequest(input);
+
+    // Assert
+    expect(result).toEqual({
+      ...input,
+      paymentMethod: { type: PayWithGoogleDetails.TypeEnum.Paywithgoogle, googlePayToken: '***' },
+    });
+  });
+
+  test('notification: masks storedPaymentMethodId in additionalData dotted keys', () => {
+    // Arrange
+    const input: NotificationRequestDTO = {
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              'tokenization.shopperReference': 'YOUR_SHOPPER_REFERENCE',
+              'tokenization.storedPaymentMethodId': 'M5N7TQ4TG5PFWR50',
+              'tokenization.store.operationType': 'created',
+            },
+            amount: { currency: 'EUR', value: 1000 },
+            eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+            eventDate: '2021-01-01T01:00:00+01:00',
+            merchantAccountCode: 'YOUR_MERCHANT_ACCOUNT',
+            merchantReference: 'YOUR_MERCHANT_REFERENCE',
+            pspReference: 'QFQTPCQ8HXSKGK82',
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = maskRequest(input);
+
+    // Assert
+    expect(result).toEqual({
+      live: 'false',
+      notificationItems: [
+        {
+          NotificationRequestItem: {
+            additionalData: {
+              'tokenization.shopperReference': 'YOUR_SHOPPER_REFERENCE',
+              'tokenization.storedPaymentMethodId': '***',
+              'tokenization.store.operationType': 'created',
+            },
+            amount: { currency: 'EUR', value: 1000 },
+            eventCode: NotificationRequestItem.EventCodeEnum.Authorisation,
+            eventDate: '2021-01-01T01:00:00+01:00',
+            merchantAccountCode: 'YOUR_MERCHANT_ACCOUNT',
+            merchantReference: 'YOUR_MERCHANT_REFERENCE',
+            pspReference: 'QFQTPCQ8HXSKGK82',
+            success: NotificationRequestItem.SuccessEnum.True,
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe('maskResponse', () => {
+  test('paymentMethod brand and type are preserved; PII in additionalData is still masked', () => {
+    // Arrange
+    const input: PaymentResponse = {
+      resultCode: PaymentResponse.ResultCodeEnum.Authorised,
+      pspReference: 'D5NHHX5ZD2LC3J75',
+      paymentMethod: { brand: 'visa', type: 'scheme' },
+      additionalData: {
+        'tokenization.storedPaymentMethodId': 'M5N7TQ4TG5PFWR50',
+        expiryDate: '3/2030',
+      },
+    };
+
+    // Act
+    const result = maskResponse(input);
+
+    // Assert
+    expect(result).toEqual({
+      resultCode: PaymentResponse.ResultCodeEnum.Authorised,
+      pspReference: 'D5NHHX5ZD2LC3J75',
+      paymentMethod: { brand: 'visa', type: 'scheme' },
+      additionalData: {
+        'tokenization.storedPaymentMethodId': '***',
+        expiryDate: '3/2030',
+      },
+    });
+  });
+});
+
+describe('populateInterfaceInteraction', () => {
+  test('returns undefined when saveInterfaceInteractions is false', () => {
+    // Arrange
+    jest.spyOn(Config, 'getConfig').mockReturnValueOnce({ saveInterfaceInteractions: false } as any);
+
+    // Act
+    const result = populateInterfaceInteraction({
+      interactionId: 'id',
+      type: 'CreatePayment',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  test('returns array with masked and serialized fields when enabled', () => {
+    // Arrange
+    jest.spyOn(Config, 'getConfig').mockReturnValueOnce({ saveInterfaceInteractions: true } as any);
+    const request: PaymentRequest = {
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'ORDER-123',
+      paymentMethod: { type: CardDetails.TypeEnum.Scheme, encryptedCardNumber: 'test_4111111111111111' },
+      returnUrl: 'https://example.com',
+      merchantAccount: 'TEST',
+      shopperEmail: 'user@example.com',
+    };
+    const response: PaymentResponse = {
+      resultCode: PaymentResponse.ResultCodeEnum.Authorised,
+      merchantReference: 'ORDER-123',
+      additionalData: { 'tokenization.storedPaymentMethodId': 'M5N7TQ4TG5PFWR50' },
+    };
+
+    // Act
+    const result = populateInterfaceInteraction({
+      interactionId: 'my-uuid',
+      type: 'CreatePayment',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      request,
+      response,
+    });
+
+    // Assert
+    expect(result).toHaveLength(1);
+    const fields = result![0].fields!;
+    expect(fields.interactionId).toEqual('my-uuid');
+    expect(fields.type).toEqual('CreatePayment');
+    expect(JSON.parse(fields.request as string)).toEqual({
+      amount: { currency: 'USD', value: 1000 },
+      reference: 'ORDER-123',
+      paymentMethod: { type: CardDetails.TypeEnum.Scheme, encryptedCardNumber: '***' },
+      returnUrl: 'https://example.com',
+      merchantAccount: 'TEST',
+      shopperEmail: '***',
+    });
+    expect(JSON.parse(fields.response as string)).toEqual({
+      resultCode: PaymentResponse.ResultCodeEnum.Authorised,
+      merchantReference: 'ORDER-123',
+      additionalData: { 'tokenization.storedPaymentMethodId': '***' },
+    });
+  });
+});


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3953

- Add ADYEN_SAVE_INTERFACE_INTERACTIONS flag that, when enabled, appends each Adyen request/response as a pspInteractions custom field entry on the CT Payment resource.
- Covered operations: create payment, confirm payment, capture, refund, cancel, reverse, and incoming notifications
- Sensitive fields are masked before storage.
- The payment-interface-interaction custom type is only provisioned on deploy when the feature is enabled. Feature is disabled by default