### PR TITLE
feat: Use Adyen as source of truth for stored payment methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ If the shopper abandons the flow and a new session is created while a previous A
 1. Ensure the configured commercetools API client has the scope `manage_types` (needed to create the custom type on deploy).
 2. Set `ADYEN_PARTIAL_PAYMENTS_ENABLED` to `"true"`. On the next re-deploy, the connector will create the `commercetools-checkout-adyen-order-details` custom type.
 3. Optionally configure `ADYEN_ORDER_EXPIRY_MINUTES` (default: `60`) to control how long an open Adyen Order stays active before expiring.
+4. In the Adyen Customer Area, on your webhook's **Additional settings** tab, under **Payment**, it is recommended to enable **"Include a success boolean for the payments listed in an ORDER_CLOSED event"**. This makes Adyen report the approval status of each partial payment directly in the `ORDER_CLOSED` webhook.
 
 #### Custom type created
 

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -106,6 +106,7 @@ import { PaypalUpdateOrderRequest } from '@adyen/api-library/lib/src/typings/che
 import { randomUUID } from 'node:crypto';
 import { TransactionDraftDTO, TransactionResponseDTO } from '../dtos/operations/transaction.dto';
 import { CURRENCIES_FROM_ISO_TO_ADYEN_MAPPING } from '../constants/currencies';
+import { StoredPaymentMethodResource } from '@adyen/api-library/lib/src/typings/checkout/storedPaymentMethodResource';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJSON = require('../../package.json');
@@ -116,10 +117,6 @@ const MODIFICATION_TYPE_MAP = {
   cancel: 'CancelPayment',
   reverse: 'ReversePayment',
 } as const;
-
-type AdyenStoredPaymentMethodToken = NonNullable<
-  Awaited<ReturnType<RecurringApi['getTokensForStoredPaymentDetails']>>['storedPaymentMethods']
->[number];
 
 export type AdyenPaymentServiceOptions = {
   ctCartService: CommercetoolsCartService;
@@ -1158,7 +1155,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * fails, so this token is simply left out of the response (see reconcileOrphanAdyenToken()).
    */
   private async resolveStoredPaymentMethod(
-    adyenToken: AdyenStoredPaymentMethodToken,
+    adyenToken: StoredPaymentMethodResource,
     ctPaymentMethod: PaymentMethod | undefined,
     context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
   ): Promise<StoredPaymentMethod | undefined> {
@@ -1174,7 +1171,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
    */
   private mapToStoredPaymentMethod(
     ctPaymentMethod: PaymentMethod,
-    adyenToken: AdyenStoredPaymentMethodToken,
+    adyenToken: StoredPaymentMethodResource,
   ): StoredPaymentMethod {
     return {
       id: ctPaymentMethod.id,
@@ -1199,7 +1196,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * fails here.
    */
   private async reconcileOrphanAdyenToken(
-    adyenToken: AdyenStoredPaymentMethodToken,
+    adyenToken: StoredPaymentMethodResource,
     context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
   ): Promise<PaymentMethod | undefined> {
     const { customerId, paymentInterface, interfaceAccount } = context;
@@ -1247,7 +1244,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * token is left out of the response until a later call reconciles it successfully.
    */
   private async fetchConcurrentlyCreatedPaymentMethod(
-    adyenToken: AdyenStoredPaymentMethodToken,
+    adyenToken: StoredPaymentMethodResource,
     context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
   ): Promise<PaymentMethod | undefined> {
     const { customerId, paymentInterface, interfaceAccount } = context;

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -14,12 +14,14 @@ import {
   ErrorRequiredField,
   PaymentMethod,
   ErrorInvalidField,
+  ErrorInternalConstraintViolated,
   CurrencyConverters,
   CustomFieldsDraft,
   FieldContainer,
 } from '@commercetools/connect-payments-sdk';
 import { AdyenOrderService } from './adyen-order.service';
 import { CheckoutOrderResponse } from '@adyen/api-library/lib/src/typings/checkout/checkoutOrderResponse';
+import type { RecurringApi } from '@adyen/api-library/lib/src/services/checkout/recurringApi';
 import {
   ConfirmPaymentRequestDTO,
   ConfirmPaymentResponseDTO,
@@ -113,6 +115,10 @@ const MODIFICATION_TYPE_MAP = {
   cancel: 'CancelPayment',
   reverse: 'ReversePayment',
 } as const;
+
+type AdyenStoredPaymentMethodToken = NonNullable<
+  Awaited<ReturnType<RecurringApi['getTokensForStoredPaymentDetails']>>['storedPaymentMethods']
+>[number];
 
 export type AdyenPaymentServiceOptions = {
   ctCartService: CommercetoolsCartService;
@@ -1036,61 +1042,170 @@ export class AdyenPaymentService extends AbstractPaymentService {
     return customerId;
   }
 
+  /**
+   * Adyen is the source of truth for *which* tokens exist for the customer (commercetools can be
+   * missing tokens that were imported into Adyen from another PSP, e.g. Braintree). commercetools
+   * is only the store for the metadata Adyen doesn't have (our own `id` used for delete,
+   * `createdAt`, `default`). Any Adyen token without a matching record is an "orphan" and gets
+   * persisted on the fly, within this same call, by reconcileOrphanAdyenToken().
+   */
   async getStoredPaymentMethods(): Promise<StoredPaymentMethodsResponse> {
     const customerId = await this.getCustomerIdFromCart();
+    const { paymentInterface, interfaceAccount } = getStoredPaymentMethodsConfig().config;
 
-    const storedPaymentMethods = await this.ctPaymentMethodService.find({
-      customerId: customerId,
-      paymentInterface: getStoredPaymentMethodsConfig().config.paymentInterface,
-      interfaceAccount: getStoredPaymentMethodsConfig().config.interfaceAccount,
-    });
+    // Fetched in parallel: neither call depends on the other's result.
+    const [adyenTokenDetails, ctStoredPaymentMethods] = await Promise.all([
+      AdyenApi().RecurringApi.getTokensForStoredPaymentDetails(customerId, getConfig().adyenMerchantAccount),
+      this.ctPaymentMethodService.find({
+        customerId,
+        paymentInterface,
+        interfaceAccount,
+      }),
+    ]);
 
-    if (storedPaymentMethods.results.length <= 0) {
+    const adyenStoredPaymentMethods = adyenTokenDetails.storedPaymentMethods ?? [];
+
+    // Nothing in Adyen means nothing to show, regardless of what commercetools has (a record without a
+    // matching Adyen token is a stale/deleted token and must not be surfaced to the customer).
+    if (adyenStoredPaymentMethods.length <= 0) {
       return { storedPaymentMethods: [] };
     }
 
-    const resList = await this.enhanceCTStoredPaymentMethodsWithAdyenDisplayData(
-      customerId,
-      storedPaymentMethods.results,
+    // Index commercetools records by token value so each Adyen token can find a match
+    // directly, instead of scanning the array per token.
+    const ctPaymentMethodByToken = new Map(
+      ctStoredPaymentMethods.results.map((paymentMethod) => [paymentMethod.token?.value, paymentMethod]),
+    );
+
+    const storedPaymentMethods = await Promise.all(
+      adyenStoredPaymentMethods.map((adyenToken) =>
+        this.resolveStoredPaymentMethod(adyenToken, ctPaymentMethodByToken.get(adyenToken.id), {
+          customerId,
+          paymentInterface,
+          interfaceAccount,
+        }),
+      ),
     );
 
     return {
-      storedPaymentMethods: resList,
+      storedPaymentMethods: storedPaymentMethods.filter((paymentMethod) => paymentMethod !== undefined),
     };
   }
 
-  async enhanceCTStoredPaymentMethodsWithAdyenDisplayData(
-    customerId: string,
-    storedPaymentMethods: PaymentMethod[],
-  ): Promise<StoredPaymentMethod[]> {
-    const customersTokenDetailsFromAdyen = await AdyenApi().RecurringApi.getTokensForStoredPaymentDetails(
-      customerId,
-      getConfig().adyenMerchantAccount,
-    );
+  /**
+   * Turns one Adyen token into a response entry. Reconciles it into commercetools first if
+   * `ctPaymentMethod` is undefined (no matching record yet). Returns undefined if reconciliation
+   * fails, so this token is simply left out of the response (see reconcileOrphanAdyenToken()).
+   */
+  private async resolveStoredPaymentMethod(
+    adyenToken: AdyenStoredPaymentMethodToken,
+    ctPaymentMethod: PaymentMethod | undefined,
+    context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
+  ): Promise<StoredPaymentMethod | undefined> {
+    const paymentMethod = ctPaymentMethod ?? (await this.reconcileOrphanAdyenToken(adyenToken, context));
 
-    return storedPaymentMethods.map((spm) => {
-      const tokenDetailsFromAdyen = customersTokenDetailsFromAdyen.storedPaymentMethods?.find(
-        (tokenDetails) => tokenDetails.id === spm.token?.value,
-      );
+    return paymentMethod ? this.mapToStoredPaymentMethod(paymentMethod, adyenToken) : undefined;
+  }
 
-      const res: StoredPaymentMethod = {
-        id: spm.id,
-        createdAt: spm.createdAt,
-        isDefault: spm.default,
-        token: spm.token?.value || tokenDetailsFromAdyen?.id || '',
-        type: spm.method || tokenDetailsFromAdyen?.type || '',
-        displayOptions: {
-          brand: {
-            key: convertAdyenCardBrandToCTFormat(tokenDetailsFromAdyen?.brand),
-          },
-          endDigits: tokenDetailsFromAdyen?.lastFour,
-          expiryMonth: tokenDetailsFromAdyen?.expiryMonth ? Number(tokenDetailsFromAdyen.expiryMonth) : undefined,
-          expiryYear: tokenDetailsFromAdyen?.expiryYear ? Number(tokenDetailsFromAdyen.expiryYear) : undefined,
+  /**
+   * Combines the commercetools record (id, createdAt, default) with Adyen's display data
+   * (brand, last four & expiry date) into the response DTO. Used for both already reconciled and
+   * newly created records.
+   */
+  private mapToStoredPaymentMethod(
+    ctPaymentMethod: PaymentMethod,
+    adyenToken: AdyenStoredPaymentMethodToken,
+  ): StoredPaymentMethod {
+    return {
+      id: ctPaymentMethod.id,
+      createdAt: ctPaymentMethod.createdAt,
+      isDefault: ctPaymentMethod.default,
+      token: ctPaymentMethod.token?.value || adyenToken.id || '',
+      type: ctPaymentMethod.method || adyenToken.type || '',
+      displayOptions: {
+        brand: {
+          key: convertAdyenCardBrandToCTFormat(adyenToken.brand),
         },
-      };
+        endDigits: adyenToken.lastFour,
+        expiryMonth: adyenToken.expiryMonth ? Number(adyenToken.expiryMonth) : undefined,
+        expiryYear: adyenToken.expiryYear ? Number(adyenToken.expiryYear) : undefined,
+      },
+    };
+  }
 
-      return res;
-    });
+  /**
+   * Persists a PaymentMethod in commercetools for a token that exists in Adyen but was never
+   * recorded there (e.g. imported from another PSP). Self-heals on the next call if persistence
+   * fails here.
+   */
+  private async reconcileOrphanAdyenToken(
+    adyenToken: AdyenStoredPaymentMethodToken,
+    context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
+  ): Promise<PaymentMethod | undefined> {
+    const { customerId, paymentInterface, interfaceAccount } = context;
+
+    try {
+      // Always created with default: false
+      const createdPaymentMethod = await this.ctPaymentMethodService.save({
+        customerId,
+        token: adyenToken.id || '',
+        paymentInterface,
+        interfaceAccount,
+        method: adyenToken.type || '',
+      });
+
+      log.info('Created payment-method in commercetools for orphaned Adyen token', {
+        customer: { id: customerId, type: 'customer' },
+        paymentMethod: { id: createdPaymentMethod.id, type: 'payment-method' },
+      });
+
+      return createdPaymentMethod;
+    } catch (error) {
+      if (error instanceof ErrorInternalConstraintViolated) {
+        // save() already checked for a record with this token.value and found one, a concurrent
+        // request (or another in-flight tab) beat us to reconciling it. Not a real failure: fetch
+        // the record that now exists instead of dropping a token the customer does have.
+        return this.fetchConcurrentlyCreatedPaymentMethod(adyenToken, context);
+      }
+
+      // Any other failure (e.g. a transient commercetools outage): log and give up on this one
+      // token. We deliberately don't fail the whole request for one bad token.
+      // The token simply won't appear until a later call successfully reconciles it.
+      log.warn('Could not create payment-method in commercetools for orphaned Adyen token; omitting from response', {
+        error,
+        customer: { id: customerId, type: 'customer' },
+      });
+
+      return undefined;
+    }
+  }
+
+  /**
+   * Fetches the commercetools record for a token that reconcileOrphanAdyenToken() failed to
+   * create because it already exists: i.e. another concurrent request won the
+   * race and created it first. Returns undefined if even this lookup fails, in which case the
+   * token is left out of the response until a later call reconciles it successfully.
+   */
+  private async fetchConcurrentlyCreatedPaymentMethod(
+    adyenToken: AdyenStoredPaymentMethodToken,
+    context: { customerId: string; paymentInterface: string; interfaceAccount?: string },
+  ): Promise<PaymentMethod | undefined> {
+    const { customerId, paymentInterface, interfaceAccount } = context;
+
+    try {
+      return await this.ctPaymentMethodService.getByTokenValue({
+        customerId,
+        tokenValue: adyenToken.id || '',
+        paymentInterface,
+        interfaceAccount,
+      });
+    } catch (error) {
+      log.warn('Could not fetch concurrently-created payment-method in commercetools for orphaned Adyen token', {
+        error,
+        customer: { id: customerId, type: 'customer' },
+      });
+      return undefined;
+    }
   }
 
   async deleteStoredPaymentMethodViaCart(id: string): Promise<void> {
@@ -1772,7 +1887,11 @@ export class AdyenPaymentService extends AbstractPaymentService {
     }
   }
 
-  private buildInterfaceInteraction(type: string, request: AdyenRequestPayload, response: AdyenResponsePayload | undefined) {
+  private buildInterfaceInteraction(
+    type: string,
+    request: AdyenRequestPayload,
+    response: AdyenResponsePayload | undefined,
+  ) {
     return populateInterfaceInteraction({
       interactionId: randomUUID(),
       type,

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -92,6 +92,7 @@ import { NotificationTokenizationConverter } from './converters/notification-rec
 import {
   buildCheckoutTransactionItemId,
   convertAdyenCardBrandToCTFormat,
+  convertPaymentMethodFromAdyenFormat,
   convertPaymentMethodToAdyenFormat,
   isGiftCardSplitPayment,
 } from './converters/helper.converter';
@@ -1180,7 +1181,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       createdAt: ctPaymentMethod.createdAt,
       isDefault: ctPaymentMethod.default,
       token: ctPaymentMethod.token?.value || adyenToken.id || '',
-      type: ctPaymentMethod.method || adyenToken.type || '',
+      type: ctPaymentMethod.method || convertPaymentMethodFromAdyenFormat(adyenToken.type as string) || '',
       displayOptions: {
         brand: {
           key: convertAdyenCardBrandToCTFormat(adyenToken.brand),
@@ -1210,7 +1211,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         token: adyenToken.id || '',
         paymentInterface,
         interfaceAccount,
-        method: adyenToken.type || '',
+        method: convertPaymentMethodFromAdyenFormat(adyenToken.type as string),
       });
 
       log.info('Created payment-method in commercetools for orphaned Adyen token', {

--- a/processor/src/services/converters/create-payment.converter.ts
+++ b/processor/src/services/converters/create-payment.converter.ts
@@ -294,10 +294,7 @@ export class CreatePaymentConverter {
           ...data,
           shopperEmail: data.shopperEmail ?? cart.customerEmail,
           telephoneNumber:
-            data.telephoneNumber ??
-            cart.billingAddress?.phone ??
-            cart.shippingAddress?.phone ??
-            undefined,
+            data.telephoneNumber ?? cart.billingAddress?.phone ?? cart.shippingAddress?.phone ?? undefined,
         });
       }
       default:
@@ -345,7 +342,7 @@ export class CreatePaymentConverter {
     const { shopperName, shopperEmail, telephoneNumber } = data;
     return {
       paymentMethod: {
-        ...data.paymentMethod as object,
+        ...(data.paymentMethod as object),
         firstName: shopperName?.firstName,
         lastName: shopperName?.lastName,
         shopperEmail: shopperEmail,

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -247,7 +247,7 @@ export class NotificationConverter {
    * needs a Refund/CancelAuthorization reflected in commercetools.
    *
    * `order-N-success` is the authoritative signal, but Adyen only includes it in additionalData
-   * when the merchant account has that field explicitly enabled — it cannot be relied upon to always be present. 
+   * when the merchant account has that field explicitly enabled — it cannot be relied upon to always be present.
    * When it's missing, we fall back to what commercetools already recorded for this leg: if there's no approved/pending
    * Charge or Authorization AND there's an explicit Failure, the leg was never approved. If neither
    * signal is available (e.g. no Charge/Authorization transaction at all yet), we default to

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -33,6 +33,7 @@ import { PaymentRest, type TPaymentRest } from '@commercetools/composable-commer
 import { CartRest, TCartRest } from '@commercetools/composable-commerce-test-data/cart';
 import {
   Cart,
+  ErrorInternalConstraintViolated,
   ErrorInvalidField,
   ErrorInvalidOperation,
   ErrorRequiredField,
@@ -1505,6 +1506,175 @@ describe('adyen-payment.service', () => {
           },
         ],
       });
+    });
+
+    test('should create a commercetools payment-method for an orphan Adyen token with default: false, without ever calling update()', async () => {
+      const customerId = '12303506-396c-4163-9193-11115c10fc2e';
+      const methodType = 'scheme';
+      const existingToken = 'adyen-token-value-existing';
+      const orphanToken = 'adyen-token-value-orphan';
+
+      const cartRandom = CartRest.random()
+        .lineItems([])
+        .customLineItems([])
+        .customerId(customerId)
+        .buildRest<TCartRest>({}) as Cart;
+
+      jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValueOnce({
+        merchantAccount: 'merchantAccount',
+        shopperReference: customerId,
+        storedPaymentMethods: [
+          { id: existingToken, type: methodType, lastFour: '1111', brand: 'visa' },
+          { id: orphanToken, type: methodType, lastFour: '2222', brand: 'mc' },
+        ],
+      });
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValueOnce(cartRandom);
+      jest.spyOn(DefaultPaymentMethodService.prototype, 'find').mockResolvedValueOnce({
+        count: 1,
+        limit: 100,
+        offset: 0,
+        results: [
+          {
+            id: 'existing-ct-id',
+            customer: { id: customerId, typeId: 'customer' },
+            token: { value: existingToken },
+            method: methodType,
+            createdAt: '2023-01-01T00:00:00.000Z',
+            lastModifiedAt: '2023-01-01T00:00:00.000Z',
+            default: true,
+            paymentMethodStatus: 'Active',
+            version: 1,
+          },
+        ],
+      });
+
+      const createdOrphan = {
+        id: 'new-ct-id',
+        customer: { id: customerId, typeId: 'customer' },
+        token: { value: orphanToken },
+        method: methodType,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        lastModifiedAt: '2024-01-01T00:00:00.000Z',
+        default: false,
+        paymentMethodStatus: 'Active',
+        version: 1,
+      } as PaymentMethod;
+
+      const saveSpy = jest.spyOn(DefaultPaymentMethodService.prototype, 'save').mockResolvedValueOnce(createdOrphan);
+      const updateSpy = jest.spyOn(DefaultPaymentMethodService.prototype, 'update');
+
+      const result = await paymentService.getStoredPaymentMethods();
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ customerId, token: orphanToken, method: methodType }),
+      );
+      expect(updateSpy).not.toHaveBeenCalled();
+      expect(result.storedPaymentMethods).toHaveLength(2);
+      expect(result.storedPaymentMethods.find((spm) => spm.id === 'new-ct-id')?.isDefault).toStrictEqual(false);
+    });
+
+    test('should recover via getByTokenValue when creating the orphan fails because it was concurrently created already', async () => {
+      const customerId = '12303506-396c-4163-9193-11115c10fc2e';
+      const methodType = 'scheme';
+      const adyenToken = 'adyen-token-value-race';
+
+      const cartRandom = CartRest.random()
+        .lineItems([])
+        .customLineItems([])
+        .customerId(customerId)
+        .buildRest<TCartRest>({}) as Cart;
+
+      jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValueOnce({
+        merchantAccount: 'merchantAccount',
+        shopperReference: customerId,
+        storedPaymentMethods: [{ id: adyenToken, type: methodType, lastFour: '1234', brand: 'visa' }],
+      });
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValueOnce(cartRandom);
+      jest.spyOn(DefaultPaymentMethodService.prototype, 'find').mockResolvedValueOnce({
+        count: 0,
+        limit: 100,
+        offset: 0,
+        results: [],
+      });
+
+      jest
+        .spyOn(DefaultPaymentMethodService.prototype, 'save')
+        .mockRejectedValueOnce(
+          new ErrorInternalConstraintViolated('A payment method with the same token already exists.'),
+        );
+
+      const concurrentlyCreated = {
+        id: 'concurrently-created-id',
+        customer: { id: customerId, typeId: 'customer' },
+        token: { value: adyenToken },
+        method: methodType,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        lastModifiedAt: '2024-01-01T00:00:00.000Z',
+        default: false,
+        paymentMethodStatus: 'Active',
+        version: 1,
+      } as PaymentMethod;
+
+      const getByTokenValueSpy = jest
+        .spyOn(DefaultPaymentMethodService.prototype, 'getByTokenValue')
+        .mockResolvedValueOnce(concurrentlyCreated);
+
+      const result = await paymentService.getStoredPaymentMethods();
+
+      expect(getByTokenValueSpy).toHaveBeenCalledWith(expect.objectContaining({ customerId, tokenValue: adyenToken }));
+      expect(result.storedPaymentMethods).toHaveLength(1);
+      expect(result.storedPaymentMethods[0].id).toStrictEqual('concurrently-created-id');
+    });
+
+    test('should omit an orphan from the response instead of failing the whole request when creating it in CT fails', async () => {
+      const customerId = '12303506-396c-4163-9193-11115c10fc2e';
+      const methodType = 'scheme';
+      const healthyToken = 'adyen-token-value-healthy';
+      const brokenToken = 'adyen-token-value-broken';
+
+      const cartRandom = CartRest.random()
+        .lineItems([])
+        .customLineItems([])
+        .customerId(customerId)
+        .buildRest<TCartRest>({}) as Cart;
+
+      jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValueOnce({
+        merchantAccount: 'merchantAccount',
+        shopperReference: customerId,
+        storedPaymentMethods: [
+          { id: healthyToken, type: methodType, lastFour: '1234', brand: 'visa' },
+          { id: brokenToken, type: methodType, lastFour: '5678', brand: 'mc' },
+        ],
+      });
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValueOnce(cartRandom);
+      jest.spyOn(DefaultPaymentMethodService.prototype, 'find').mockResolvedValueOnce({
+        count: 0,
+        limit: 100,
+        offset: 0,
+        results: [],
+      });
+
+      const createdHealthy = {
+        id: 'healthy-ct-id',
+        customer: { id: customerId, typeId: 'customer' },
+        token: { value: healthyToken },
+        method: methodType,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        lastModifiedAt: '2024-01-01T00:00:00.000Z',
+        default: false,
+        paymentMethodStatus: 'Active',
+        version: 1,
+      } as PaymentMethod;
+
+      jest
+        .spyOn(DefaultPaymentMethodService.prototype, 'save')
+        .mockResolvedValueOnce(createdHealthy)
+        .mockRejectedValueOnce(new Error('CT is temporarily unavailable'));
+
+      const result = await paymentService.getStoredPaymentMethods();
+
+      expect(result.storedPaymentMethods).toHaveLength(1);
+      expect(result.storedPaymentMethods[0].id).toStrictEqual('healthy-ct-id');
     });
   });
 

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -1705,7 +1705,7 @@ describe('adyen-payment.service', () => {
       const result = await paymentService.getStoredPaymentMethods();
 
       expect(saveSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ customerId, token: orphanToken, method: methodType }),
+        expect.objectContaining({ customerId, token: orphanToken, method: 'card' }),
       );
       expect(updateSpy).not.toHaveBeenCalled();
       expect(result.storedPaymentMethods).toHaveLength(2);


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3955

We are changing the way we get the store payment methods from the buyer. Adyen will be the source of truth from now on. 
The connector now lists tokens from Adyen first and reconciles any orphan into commercetools on the fly, instead of relying on commercetools as the primary source.