### PR TITLE
fix(payments): avoid duplicate refund transactions when a gift card multi-payment order is reversed

### DIFF
--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -812,24 +812,25 @@ export class AdyenPaymentService extends AbstractPaymentService {
     const hasCharge = transactionStateChecker('Charge', ['Success']);
     const hasAuthorization = transactionStateChecker('Authorization', ['Success']);
 
-    let response!: PaymentProviderModificationResponse;
+    let transactionType: 'Refund' | 'CancelAuthorization';
     if (hasCharge) {
-      response = await this.processPaymentModificationInternal({
-        request,
-        transactionType: 'Refund',
-        adyenOperation: 'reverse',
-        amount: request.payment.amountPlanned,
-      });
+      transactionType = 'Refund';
     } else if (hasAuthorization) {
-      response = await this.processPaymentModificationInternal({
-        request,
-        transactionType: 'CancelAuthorization',
-        adyenOperation: 'reverse',
-        amount: request.payment.amountPlanned,
-      });
+      transactionType = 'CancelAuthorization';
     } else {
       throw new ErrorInvalidOperation(`There is no successful payment transaction to reverse.`);
     }
+
+    const adyenOrder = this.getAdyenOrderReference(request.payment);
+
+    const response = adyenOrder
+      ? await this.reverseOrderPayment({ request, transactionType, ...adyenOrder })
+      : await this.processPaymentModificationInternal({
+          request,
+          transactionType,
+          adyenOperation: 'reverse',
+          amount: request.payment.amountPlanned,
+        });
 
     log.info(`Payment modification completed.`, {
       paymentId: request.payment.id,
@@ -838,6 +839,64 @@ export class AdyenPaymentService extends AbstractPaymentService {
     });
 
     return response;
+  }
+
+  /**
+   * Returns the Adyen order reference for a payment that is part of a partial/multi payment
+   * (gift card + card), or undefined if the payment was not created as part of such an order.
+   */
+  private getAdyenOrderReference(
+    payment: Payment,
+  ): { adyenOrderData: string; adyenOrderPspReference: string } | undefined {
+    const adyenOrderData = payment.custom?.fields?.['adyenOrderData'] as string | undefined;
+    const adyenOrderPspReference = payment.custom?.fields?.['adyenOrderPspReference'] as string | undefined;
+
+    return adyenOrderData && adyenOrderPspReference ? { adyenOrderData, adyenOrderPspReference } : undefined;
+  }
+
+  /**
+   * Reverses a payment that belongs to an Adyen order (partial/multi payments, e.g. gift card + card)
+   * by cancelling the order itself instead of calling the modification API on the individual payment.
+   */
+  private async reverseOrderPayment(opts: {
+    request: ReversePaymentRequest;
+    transactionType: 'Refund' | 'CancelAuthorization';
+    adyenOrderData: string;
+    adyenOrderPspReference: string;
+  }): Promise<PaymentProviderModificationResponse> {
+    const { request, transactionType, adyenOrderData, adyenOrderPspReference } = opts;
+
+    await this.ctPaymentService.updatePayment({
+      id: request.payment.id,
+      transaction: {
+        type: transactionType,
+        amount: request.payment.amountPlanned,
+        state: 'Initial',
+      },
+    });
+
+    const adyenResponse = await this.orderService.cancelOrder({
+      data: { orderData: adyenOrderData, pspReference: adyenOrderPspReference },
+    });
+
+    log.info(`Adyen order cancellation requested as part of payment reversal.`, {
+      paymentId: request.payment.id,
+      adyenOrderPspReference,
+      cancellationRequestPspReference: adyenResponse.pspReference,
+    });
+
+    await this.ctPaymentService.updatePayment({
+      id: request.payment.id,
+      transaction: {
+        type: transactionType,
+        amount: request.payment.amountPlanned,
+        interactionId: adyenOrderPspReference, // Deprecated but kept for backward compatibility
+        interfaceId: adyenOrderPspReference,
+        state: this.convertPaymentModificationOutcomeToState(PaymentModificationStatus.RECEIVED),
+      },
+    });
+
+    return { outcome: PaymentModificationStatus.RECEIVED, pspReference: adyenOrderPspReference };
   }
 
   private async handleTransactionRecurringType(transactionDraft: TransactionDraftDTO): Promise<TransactionResponseDTO> {
@@ -1745,7 +1804,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         paymentMethod: opts.paymentMethod,
         amountPlanned: cartAmount,
       });
-      if (balanceResponse.balance) {
+      if (balanceResponse.balance && balanceResponse.balance.value > 0) {
         return {
           centAmount: Math.min(balanceResponse.balance.value, cartAmount.centAmount),
           currencyCode: balanceResponse.balance.currency,
@@ -1772,7 +1831,11 @@ export class AdyenPaymentService extends AbstractPaymentService {
     }
   }
 
-  private buildInterfaceInteraction(type: string, request: AdyenRequestPayload, response: AdyenResponsePayload | undefined) {
+  private buildInterfaceInteraction(
+    type: string,
+    request: AdyenRequestPayload,
+    response: AdyenResponsePayload | undefined,
+  ) {
     return populateInterfaceInteraction({
       interactionId: randomUUID(),
       type,

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -16,6 +16,7 @@ import { NotificationUpdatePayment } from '../types/service.type';
 import { CURRENCIES_FROM_ADYEN_TO_ISO_MAPPING } from '../../constants/currencies';
 import { convertAdyenCardBrandToCTFormat, convertAdyenGiftCardBrandToCTFormat } from './helper.converter';
 import { getConfig } from '../../config/config';
+import { log } from '../../libs/logger';
 
 export class NotificationConverter {
   private ctPaymentService: CommercetoolsPaymentService;
@@ -181,10 +182,27 @@ export class NotificationConverter {
     // success: false — order expired or was cancelled. Adyen automatically refunds gift card partial
     // payments but does not send individual REFUND webhooks for them. We use ORDER_CLOSED as the
     // trigger to mark each partial payment as reversed in commercetools.
+    //
+    // Each leg carries its own `order-N-success` flag. A leg can be present on the order without
+    // ever having been approved — e.g. in a gift card + card split payment, the card leg that failed
+    // (and triggered the order cancellation in the first place) was never authorised/charged. There is
+    // nothing to reverse for that leg, so we skip it based on its own success flag rather than assuming
+    // every leg on the order was approved just because the order itself carried the pspReference.
     const results: NotificationUpdatePayment[] = [];
     let n = 1;
     while (item.additionalData?.[`order-${n}-pspReference`]) {
       const partialPspReference = item.additionalData[`order-${n}-pspReference`] as string;
+      const wasApproved = item.additionalData[`order-${n}-success`] === NotificationRequestItem.SuccessEnum.True;
+
+      if (!wasApproved) {
+        log.info('Skipping order-closed reversal for a partial payment that was never approved.', {
+          merchantReference: item.merchantReference,
+          pspReference: partialPspReference,
+        });
+        n++;
+        continue;
+      }
+
       const payments = await this.ctPaymentService.findPaymentsByInterfaceId({ interfaceId: partialPspReference });
       const ctPayment = payments[0];
 

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -68,6 +68,7 @@ import { StoredPaymentMethod } from '../../src/dtos/stored-payment-methods.dto';
 import * as StoredPaymentMethodsConfig from '../../src/config/stored-payment-methods.config';
 import { HttpClientException } from '@adyen/api-library';
 import { TransactionDraftDTO } from '../../src/dtos/operations/transaction.dto';
+import { BalanceCheckResponse, CancelOrderResponse } from '@adyen/api-library/lib/src/typings/checkout/models';
 
 interface FlexibleConfig {
   [key: string]: string; // Adjust the type according to your config values
@@ -642,6 +643,143 @@ describe('adyen-payment.service', () => {
     const result = await adyenPaymentService.createPayment(createPaymentOpts);
     expect(result?.resultCode).toStrictEqual(PaymentResponse.ResultCodeEnum.Received);
     expect(result?.paymentReference).toStrictEqual('123456');
+  });
+
+  describe('reversePayment', () => {
+    const paymentWithSuccessfulCharge: Payment = {
+      ...mockGetPaymentResult,
+      transactions: [
+        {
+          id: 'tx-charge',
+          type: 'Charge',
+          state: 'Success',
+          amount: { type: 'centPrecision', centAmount: 120000, currencyCode: 'GBP', fractionDigits: 2 },
+          timestamp: '2024-02-13T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const paymentWithAdyenOrder: Payment = {
+      ...paymentWithSuccessfulCharge,
+      custom: {
+        type: { typeId: 'type', id: 'custom-type-id' },
+        fields: { adyenOrderData: 'some-order-data', adyenOrderPspReference: 'ORDER-PSP-123' },
+      },
+    };
+
+    test('reverses the individual payment via the modification API when there is no Adyen order', async () => {
+      // Given
+      const updateSpy = jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockResolvedValue(mockUpdatePaymentResult);
+      const reversalSpy = jest.spyOn(ModificationsApi.prototype, 'refundOrCancelPayment').mockResolvedValue({
+        status: 'received' as never,
+        pspReference: 'REVERSAL-PSP-789',
+        paymentPspReference: paymentWithSuccessfulCharge.interfaceId as string,
+        merchantAccount: 'adyenMerchantAccount',
+      });
+      const cancelOrderSpy = jest.spyOn(OrdersApi.prototype, 'cancelOrder');
+
+      // Act
+      const result = await paymentService.reversePayment({ payment: paymentWithSuccessfulCharge });
+
+      // Expect
+      expect(cancelOrderSpy).not.toHaveBeenCalled();
+      expect(reversalSpy).toHaveBeenCalledWith(
+        paymentWithSuccessfulCharge.interfaceId as string,
+        expect.objectContaining({ reference: paymentWithSuccessfulCharge.id }),
+      );
+      expect(result.outcome).toStrictEqual('received');
+      expect(result.pspReference).toStrictEqual('REVERSAL-PSP-789');
+      expect(updateSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          transaction: expect.objectContaining({
+            type: 'Refund',
+            interactionId: 'REVERSAL-PSP-789',
+            interfaceId: 'REVERSAL-PSP-789',
+          }),
+        }),
+      );
+    });
+
+    test('cancels the Adyen order instead of reversing the leg when the payment belongs to an Adyen order', async () => {
+      // Given
+      const updateSpy = jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockResolvedValue(mockUpdatePaymentResult);
+      const cancelOrderSpy = jest.spyOn(OrdersApi.prototype, 'cancelOrder').mockResolvedValue({
+        pspReference: 'CANCEL-REQUEST-PSP-456',
+        resultCode: CancelOrderResponse.ResultCodeEnum.Received,
+      });
+      const reversalSpy = jest.spyOn(ModificationsApi.prototype, 'refundOrCancelPayment');
+
+      // Act
+      const result = await paymentService.reversePayment({ payment: paymentWithAdyenOrder });
+
+      // Expect
+      expect(reversalSpy).not.toHaveBeenCalled();
+      expect(cancelOrderSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: { orderData: 'some-order-data', pspReference: 'ORDER-PSP-123' },
+        }),
+      );
+      // The transaction must be stamped with the order's own pspReference — not the cancellation
+      // request's own pspReference — so it later matches the ORDER_CLOSED webhook.
+      expect(result.outcome).toStrictEqual('received');
+      expect(result.pspReference).toStrictEqual('ORDER-PSP-123');
+      expect(updateSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          transaction: expect.objectContaining({
+            type: 'Refund',
+            interactionId: 'ORDER-PSP-123',
+            interfaceId: 'ORDER-PSP-123',
+          }),
+        }),
+      );
+    });
+
+    test('uses CancelAuthorization when the Adyen order payment only has a successful Authorization', async () => {
+      // Given
+      const paymentWithAdyenOrderAuthOnly: Payment = {
+        ...paymentWithAdyenOrder,
+        transactions: [
+          {
+            id: 'tx-auth',
+            type: 'Authorization',
+            state: 'Success',
+            amount: { type: 'centPrecision', centAmount: 120000, currencyCode: 'GBP', fractionDigits: 2 },
+            timestamp: '2024-02-13T00:00:00.000Z',
+          },
+        ],
+      };
+      const updateSpy = jest
+        .spyOn(DefaultPaymentService.prototype, 'updatePayment')
+        .mockResolvedValue(mockUpdatePaymentResult);
+      jest.spyOn(OrdersApi.prototype, 'cancelOrder').mockResolvedValue({
+        pspReference: 'CANCEL-REQUEST-PSP-456',
+        resultCode: CancelOrderResponse.ResultCodeEnum.Received,
+      });
+
+      // Act
+      await paymentService.reversePayment({ payment: paymentWithAdyenOrderAuthOnly });
+
+      // Expect
+      expect(updateSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          transaction: expect.objectContaining({ type: 'CancelAuthorization', interactionId: 'ORDER-PSP-123' }),
+        }),
+      );
+    });
+
+    test('throws when there is no successful Charge or Authorization to reverse', async () => {
+      // Given
+      const paymentWithoutSuccessfulTransaction: Payment = { ...mockGetPaymentResult, transactions: [] };
+
+      // Act & Expect
+      await expect(paymentService.reversePayment({ payment: paymentWithoutSuccessfulTransaction })).rejects.toThrow(
+        'There is no successful payment transaction to reverse.',
+      );
+    });
   });
 
   describe('interface interactions', () => {
@@ -2323,7 +2461,7 @@ describe('adyen-payment.service', () => {
       jest.spyOn(OrdersApi.prototype, 'getBalanceOfGiftCard').mockResolvedValue({
         balance: { value: 5000, currency: 'USD' },
         pspReference: 'BALANCE-PSP-1',
-        resultCode: 'Success',
+        resultCode: BalanceCheckResponse.ResultCodeEnum.Success,
       });
 
       const adyenPaymentService = new AdyenPaymentService(opts);
@@ -2341,7 +2479,7 @@ describe('adyen-payment.service', () => {
       jest.spyOn(OrdersApi.prototype, 'getBalanceOfGiftCard').mockResolvedValue({
         balance: { value: 200000, currency: 'USD' },
         pspReference: 'BALANCE-PSP-2',
-        resultCode: 'Success',
+        resultCode: BalanceCheckResponse.ResultCodeEnum.Success,
       });
 
       const adyenPaymentService = new AdyenPaymentService(opts);
@@ -2357,8 +2495,8 @@ describe('adyen-payment.service', () => {
     test('falls back to cart amount when balance check returns no balance', async () => {
       jest.spyOn(OrdersApi.prototype, 'getBalanceOfGiftCard').mockResolvedValue({
         pspReference: 'BALANCE-PSP-3',
-        resultCode: 'NotEnoughBalance',
-      });
+        resultCode: BalanceCheckResponse.ResultCodeEnum.NotEnoughBalance,
+      } as BalanceCheckResponse);
 
       const adyenPaymentService = new AdyenPaymentService(opts);
       await adyenPaymentService.createPayment(giftCardPaymentOpts);

--- a/processor/test/services/converters/notification.converter.spec.ts
+++ b/processor/test/services/converters/notification.converter.spec.ts
@@ -1300,6 +1300,7 @@ describe('notification.converter', () => {
                 'order-1-pspReference': 'GIFT_CARD_PSP',
                 'order-1-paymentAmount': 'EUR 50.00',
                 'order-1-paymentMethod': 'givex',
+                'order-1-success': NotificationRequestItem.SuccessEnum.True,
               },
               amount: { currency: 'EUR', value: 5000 },
               eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
@@ -1362,6 +1363,7 @@ describe('notification.converter', () => {
                 'order-1-pspReference': 'GIFT_CARD_PSP',
                 'order-1-paymentAmount': 'EUR 50.00',
                 'order-1-paymentMethod': 'givex',
+                'order-1-success': NotificationRequestItem.SuccessEnum.True,
               },
               amount: { currency: 'EUR', value: 5000 },
               eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
@@ -1408,6 +1410,7 @@ describe('notification.converter', () => {
               additionalData: {
                 'order-1-pspReference': 'UNKNOWN_PSP',
                 'order-1-paymentAmount': 'EUR 50.00',
+                'order-1-success': NotificationRequestItem.SuccessEnum.True,
               },
               amount: { currency: 'EUR', value: 5000 },
               eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
@@ -1426,6 +1429,76 @@ describe('notification.converter', () => {
 
       // Assert
       expect(result).toEqual([]);
+    });
+
+    test('skips a partial payment leg that was never approved (e.g. the card leg failed in a gift card + card split payment)', async () => {
+      // Arrange: gift card leg succeeded, card leg never got approved and triggered the order cancellation.
+      const mockGiftCardPaymentWithCharge = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP',
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Success',
+            id: 'tx-1',
+            amount: { centAmount: 3000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+
+      const findPaymentsByInterfaceIdSpy = jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([mockGiftCardPaymentWithCharge] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP',
+                'order-1-paymentAmount': 'EUR 30.00',
+                'order-1-paymentMethod': 'givex',
+                'order-1-success': NotificationRequestItem.SuccessEnum.True,
+                'order-2-pspReference': 'CARD_PSP',
+                'order-2-paymentAmount': 'EUR 20.00',
+                'order-2-paymentMethod': 'visa',
+                'order-2-success': NotificationRequestItem.SuccessEnum.False,
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert: only the approved gift card leg is reversed; the never-approved card leg is skipped
+      // and never even looked up in commercetools.
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP',
+          transactions: [
+            {
+              type: 'Refund',
+              state: 'Success',
+              amount: { centAmount: 3000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+      ]);
+      expect(findPaymentsByInterfaceIdSpy).toHaveBeenCalledWith({ interfaceId: 'GIFT_CARD_PSP' });
+      expect(findPaymentsByInterfaceIdSpy).not.toHaveBeenCalledWith({ interfaceId: 'CARD_PSP' });
     });
 
     test('returns multiple NotificationUpdatePayment objects for multiple partial payments', async () => {
@@ -1470,9 +1543,11 @@ describe('notification.converter', () => {
                 'order-1-pspReference': 'GIFT_CARD_PSP_1',
                 'order-1-paymentAmount': 'EUR 30.00',
                 'order-1-paymentMethod': 'givex',
+                'order-1-success': NotificationRequestItem.SuccessEnum.True,
                 'order-2-pspReference': 'GIFT_CARD_PSP_2',
                 'order-2-paymentAmount': 'EUR 20.00',
                 'order-2-paymentMethod': 'givex',
+                'order-2-success': NotificationRequestItem.SuccessEnum.True,
               },
               amount: { currency: 'EUR', value: 5000 },
               eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3983

When a partial/multi payment (gift card + card) needs to be reversed, checkout's own session-recreation flow can concurrently cancel the same Adyen order (cancelCartActiveOrders).
Reversing the individual leg via the reversal API produced a different pspReference than the order-level ORDER_CLOSED webhook, so commercetools ended up creating two Refund/CancelAuthorization transactions for the same cancellation.

reversePayment now cancels the Adyen order itself (instead of the individual leg) whenever the payment belongs to one, stamping the transaction with the order's own pspReference so it converges with the ORDER_CLOSED webhook no matter how many times the cancellation ends up being triggered.