### PR TITLE
fix(payments): set a fallback when we don't receive for adyen information about the payment status in the order closed event

### DIFF
--- a/processor/package-lock.json
+++ b/processor/package-lock.json
@@ -1007,6 +1007,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -1073,6 +1090,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
@@ -4682,6 +4706,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
@@ -4694,6 +4735,13 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "10.2.5",
@@ -5037,9 +5085,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -9362,6 +9410,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {

--- a/processor/package.json
+++ b/processor/package.json
@@ -63,6 +63,11 @@
   "overrides": {
     "lodash": "4.18.1",
     "brace-expansion": "5.0.7",
-    "ajv": "8.20.0"
+    "@commercetools/composable-commerce-test-data": {
+      "@commercetools-frontend/application-config": {
+        "ajv": "8.20.0",
+        "dompurify": "3.4.12"
+      }
+    }
   }
 }

--- a/processor/src/services/converters/notification.converter.ts
+++ b/processor/src/services/converters/notification.converter.ts
@@ -1,4 +1,5 @@
 import { NotificationRequestItem } from '@adyen/api-library/lib/src/typings/notification/notificationRequestItem';
+import { Transaction } from '@commercetools/platform-sdk';
 import { NotificationRequestDTO } from '../../dtos/adyen-payment.dto';
 import {
   TransactionData,
@@ -183,18 +184,20 @@ export class NotificationConverter {
     // payments but does not send individual REFUND webhooks for them. We use ORDER_CLOSED as the
     // trigger to mark each partial payment as reversed in commercetools.
     //
-    // Each leg carries its own `order-N-success` flag. A leg can be present on the order without
-    // ever having been approved — e.g. in a gift card + card split payment, the card leg that failed
-    // (and triggered the order cancellation in the first place) was never authorised/charged. There is
-    // nothing to reverse for that leg, so we skip it based on its own success flag rather than assuming
-    // every leg on the order was approved just because the order itself carried the pspReference.
+    // A leg can be present on the order without ever having been approved — e.g. in a gift card +
+    // card split payment, the card leg that failed (and triggered the order cancellation in the
+    // first place) was never authorised/charged. There is nothing to reverse for that leg, so we
+    // skip it rather than assuming every leg on the order was approved just because the order
+    // itself carried the pspReference. See wasPartialPaymentApproved for how that's determined.
     const results: NotificationUpdatePayment[] = [];
     let n = 1;
     while (item.additionalData?.[`order-${n}-pspReference`]) {
       const partialPspReference = item.additionalData[`order-${n}-pspReference`] as string;
-      const wasApproved = item.additionalData[`order-${n}-success`] === NotificationRequestItem.SuccessEnum.True;
+      const successFlag = item.additionalData[`order-${n}-success`] as string | undefined;
 
-      if (!wasApproved) {
+      // Fast path: Adyen told us explicitly this leg was never approved — nothing to reverse,
+      // no need to even look up the commercetools payment for it.
+      if (successFlag === NotificationRequestItem.SuccessEnum.False) {
         log.info('Skipping order-closed reversal for a partial payment that was never approved.', {
           merchantReference: item.merchantReference,
           pspReference: partialPspReference,
@@ -206,7 +209,7 @@ export class NotificationConverter {
       const payments = await this.ctPaymentService.findPaymentsByInterfaceId({ interfaceId: partialPspReference });
       const ctPayment = payments[0];
 
-      if (ctPayment) {
+      if (ctPayment && this.wasPartialPaymentApproved(successFlag, ctPayment)) {
         const hasSuccessfulCharge = ctPayment.transactions.some((tx) => tx.type === 'Charge' && tx.state === 'Success');
         const transactionType = hasSuccessfulCharge ? 'Refund' : 'CancelAuthorization';
         const originalTx = ctPayment.transactions.find(
@@ -225,6 +228,12 @@ export class NotificationConverter {
             },
           ],
         });
+      } else if (ctPayment) {
+        log.info('Skipping order-closed reversal for a partial payment that was never approved.', {
+          merchantReference: item.merchantReference,
+          pspReference: partialPspReference,
+          paymentId: ctPayment.id,
+        });
       }
 
       n++;
@@ -232,6 +241,32 @@ export class NotificationConverter {
 
     return results;
   };
+
+  /**
+   * Whether a partial payment leg on a cancelled Adyen order was actually approved, and therefore
+   * needs a Refund/CancelAuthorization reflected in commercetools.
+   *
+   * `order-N-success` is the authoritative signal, but Adyen only includes it in additionalData
+   * when the merchant account has that field explicitly enabled — it cannot be relied upon to always be present. 
+   * When it's missing, we fall back to what commercetools already recorded for this leg: if there's no approved/pending
+   * Charge or Authorization AND there's an explicit Failure, the leg was never approved. If neither
+   * signal is available (e.g. no Charge/Authorization transaction at all yet), we default to
+   * treating the leg as approved — silently skipping a leg that actually needs reversing is worse
+   * than creating one extra transaction for a leg that turns out not to have needed it.
+   */
+  private wasPartialPaymentApproved(successFlag: string | undefined, ctPayment: Payment): boolean {
+    if (successFlag !== undefined) {
+      return successFlag === NotificationRequestItem.SuccessEnum.True;
+    }
+
+    const isChargeOrAuthorization = (tx: Transaction) => tx.type === 'Charge' || tx.type === 'Authorization';
+    const hasApprovedOrPending = ctPayment.transactions.some(
+      (tx) => isChargeOrAuthorization(tx) && (tx.state === 'Success' || tx.state === 'Pending'),
+    );
+    const hasFailure = ctPayment.transactions.some((tx) => isChargeOrAuthorization(tx) && tx.state === 'Failure');
+
+    return hasApprovedOrPending || !hasFailure;
+  }
 
   private POPULATE_TRANSACTIONS_MAPPER: Partial<
     Record<

--- a/processor/src/services/converters/payment-components.converter.ts
+++ b/processor/src/services/converters/payment-components.converter.ts
@@ -92,7 +92,7 @@ export class PaymentComponentsConverter {
         },
         {
           type: 'jcs', // econtext_stores
-        }
+        },
       ],
       express: [
         {

--- a/processor/test/services/converters/notification.converter.spec.ts
+++ b/processor/test/services/converters/notification.converter.spec.ts
@@ -1501,6 +1501,144 @@ describe('notification.converter', () => {
       expect(findPaymentsByInterfaceIdSpy).not.toHaveBeenCalledWith({ interfaceId: 'CARD_PSP' });
     });
 
+    test('falls back to the CT payment transactions when order-N-success is absent (not enabled in Adyen) and skips a leg with only a Failure', async () => {
+      // Arrange: same scenario as above, but the merchant account does not have order-N-success
+      // enabled, so Adyen never sends the flag at all. The card leg only has a Failure transaction
+      // recorded in commercetools — no approved/pending Charge or Authorization — so we should still
+      // detect it was never approved and skip it.
+      const mockGiftCardPaymentWithCharge = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP',
+        transactions: [
+          {
+            type: 'Charge',
+            state: 'Success',
+            id: 'tx-1',
+            amount: { centAmount: 3000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+      const mockCardPaymentWithFailureOnly = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'CARD_PSP',
+        transactions: [
+          {
+            type: 'Authorization',
+            state: 'Failure',
+            id: 'tx-2',
+            amount: { centAmount: 2000, currencyCode: 'EUR' },
+          },
+        ],
+      };
+
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValueOnce([mockGiftCardPaymentWithCharge] as any)
+        .mockResolvedValueOnce([mockCardPaymentWithFailureOnly] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP',
+                'order-1-paymentAmount': 'EUR 30.00',
+                'order-1-paymentMethod': 'givex',
+                // no order-1-success / order-2-success — not enabled on this merchant account
+                'order-2-pspReference': 'CARD_PSP',
+                'order-2-paymentAmount': 'EUR 20.00',
+                'order-2-paymentMethod': 'visa',
+              },
+              amount: { currency: 'EUR', value: 5000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert: only the gift card leg (which has an approved Charge) is reversed.
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP',
+          transactions: [
+            {
+              type: 'Refund',
+              state: 'Success',
+              amount: { centAmount: 3000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+      ]);
+    });
+
+    test('falls back to treating the leg as approved when order-N-success is absent and the CT payment has no Charge/Authorization at all', async () => {
+      // Arrange: no success flag, and no signal either way in commercetools (edge case) — defaults
+      // to approved so we don't silently drop a leg that might actually need reversing.
+      const mockPaymentWithNoAuthOrCharge = {
+        ...mockUpdatePaymentResult,
+        interfaceId: 'GIFT_CARD_PSP',
+        transactions: [],
+      };
+
+      jest
+        .spyOn(DefaultPaymentService.prototype, 'findPaymentsByInterfaceId')
+        .mockResolvedValue([mockPaymentWithNoAuthOrCharge] as any);
+
+      const merchantReference = 'some-merchant-reference';
+      const notification: NotificationRequestDTO = {
+        live: 'false',
+        notificationItems: [
+          {
+            NotificationRequestItem: {
+              additionalData: {
+                'order-1-pspReference': 'GIFT_CARD_PSP',
+                'order-1-paymentAmount': 'EUR 30.00',
+                'order-1-paymentMethod': 'givex',
+              },
+              amount: { currency: 'EUR', value: 3000 },
+              eventCode: NotificationRequestItem.EventCodeEnum.OrderClosed,
+              eventDate: '2024-06-17T11:37:05+02:00',
+              merchantAccountCode: 'MyMerchantAccount',
+              merchantReference,
+              pspReference: 'ORDER_PSP',
+              success: NotificationRequestItem.SuccessEnum.False,
+            },
+          },
+        ],
+      };
+
+      // Act
+      const result = await converter.convert({ data: notification });
+
+      // Assert: defaults to CancelAuthorization (no successful Charge found) rather than skipping.
+      expect(result).toEqual([
+        {
+          merchantReference,
+          pspReference: 'GIFT_CARD_PSP',
+          transactions: [
+            {
+              type: 'CancelAuthorization',
+              state: 'Success',
+              amount: { centAmount: 3000, currencyCode: 'EUR' },
+              interactionId: 'ORDER_PSP',
+            },
+          ],
+        },
+      ]);
+    });
+
     test('returns multiple NotificationUpdatePayment objects for multiple partial payments', async () => {
       // Arrange
       const mockPaymentWithCharge = {


### PR DESCRIPTION
- Adyen only includes order-N-success in the ORDER_CLOSED webhook's additionalData when the merchant account has that field explicitly enabled in the webhook's Additional settings. Without it, every partial-payment leg on a cancelled multi-payment order (gift card + card) was treated as unapproved and silently skipped — including legs that actually succeeded and needed a Refund/CancelAuthorization.
- Adds a fallback: when the flag is missing, the connector checks commercetools' own transaction history for that leg — an approved/pending Charge or Authorization means it was approved; an explicit Failure with no approved/pending transaction means it wasn't. If neither signal is available, it defaults to treating the leg as approved (a missed skip is worse than one extra transaction).
- Documents in the README that enabling "Include a success boolean for the payments listed in an ORDER_CLOSED event" in Adyen is recommended, since it's the more direct signal.