### PR TITLE
fix: disable bump to TS 7

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,12 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+      # ts-jest 29.4.12 (latest) peer-requires typescript ">=4.3 <7", and its
+      # transpiler hardcodes require("typescript"), which TS 7's native compiler
+      # cannot satisfy - the test suites fail to run. 6.x is fine, so only pin
+      # out 7+; drop this once ts-jest ships TypeScript 7 support.
+      - dependency-name: "typescript"
+        versions: [">=7"]
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -45,6 +51,12 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+      # ts-jest 29.4.12 (latest) peer-requires typescript ">=4.3 <7", and its
+      # transpiler hardcodes require("typescript"), which TS 7's native compiler
+      # cannot satisfy - the test suites fail to run. 6.x is fine, so only pin
+      # out 7+; drop this once ts-jest ships TypeScript 7 support.
+      - dependency-name: "typescript"
+        versions: [">=7"]
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
ts-jest 29.4.12 (latest) peer-requires typescript ">=4.3 <7", so a TS 7 bump fails to install. Forcing the peer past that only moves the failure to runtime: ts-jest's transpiler hardcodes require("typescript") and TS 7 is the native compiler, which no longer exposes the JavaScript compiler API it needs, so every test suite fails to run.

Closing the 7.0.2 PRs alone would not hold - Dependabot only suppresses the exact version closed, and would reopen on the next 7.x release. Pin out >=7 rather than all majors, so 6.x updates keep flowing.

Applied to both the /processor and /enabler entries: both use ts-jest, and node10 module resolution (which the processors rely on for their test transform) stops functioning entirely in TS 7.

Revert once ts-jest supports TypeScript 7.