### PR TITLE
feat(recurring-orders): add support for processing server to server payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,21 @@ When a payment method is tokenized for the first time Adyen will send a new noti
 
 The next time the same customer goes through Checkout (either using drop-ins or web-components) they will see the stored payment method as a option to pay with.
 
+### Server-to-server recurring payments
+
+Once a payment method has been tokenized (see [stored payment methods](#stored-payment-methods) above), a backend system - for example Checkout when processing a recurring payment - can charge that stored payment method directly, server-to-server. This is a different flow from the client-to-server flows described above: there is no shopper session and no redirect involved, since the shopper is not present when the charge happens.
+
+#### Endpoint
+
+`POST /operations/transactions`
+
+For the full request/response contract, see [Create transaction](./processor/README.md#create-transaction) in the processor documentation.
+
+#### Requirements
+
+- The stored payment methods feature must be enabled (see [Setting up stored payment methods](#setting-up-stored-payment-methods)) - a token to charge must already exist.
+- The caller must present an OAuth2 token with the `manage_project` and `manage_checkout_transactions` scopes.
+
 ### Save displayable payment method details
 
 This feature will ensure that on the `payment.paymentMethodInfo` and the `payment-methods` entities the `custom` property is filled with the specific payment details.

--- a/processor/README.md
+++ b/processor/README.md
@@ -469,11 +469,15 @@ Private endpoint used for server-to-server payment processing, for example to ch
 
 - cartId: Id of the cart to charge.
 - checkoutTransactionItemId: Id of the checkout payment-transaction item this request is processing. The commercetools Payment created for this charge is linked to this value.
-- amount
+- paymentInterface (optional): Deprecated, do not use.
+- amount (optional)
   - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5. It must match the currency and not exceed the outstanding amount of the cart, otherwise the request is rejected.
   - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
-- paymentMethodId: Id of the previously stored payment method to charge.
-- idempotencyKey: Key used to make repeated requests for the same charge attempt idempotent, both towards this endpoint and towards Adyen.
+
+  When omitted, the cart's outstanding amount is charged instead, and no currency/amount validation against the cart is performed.
+- paymentMethodId: Id of the previously stored payment method to charge. Required to process the charge.
+- idempotencyKey (optional): Key used to make repeated requests for the same charge attempt idempotent, both towards this endpoint and towards Adyen. When omitted, requests towards Adyen are not idempotent.
+- futureOrderNumber (optional): Merchant order reference sent to Adyen as `merchantOrderReference`.
 - type: Type of transaction to process. Currently only `Recurring` is supported.
 
 #### Response Parameters

--- a/processor/README.md
+++ b/processor/README.md
@@ -74,7 +74,6 @@ Setup correct environment variables: check `processor/src/config/config.ts` for 
 Make sure commercetools client credential have at least the following permissions:
 
 - `manage_payments`
-- `manage_checkout_payment_intents`
 - `view_sessions`
 - `introspect_oauth_tokens`
 
@@ -456,6 +455,42 @@ The request payload is different based on different update operations:
     outcome: "approved|rejected|received"
 }
 
+```
+
+### Create transaction
+
+Private endpoint used for server-to-server payment processing, for example to charge a recurring order's billing cycle using a previously stored payment method. Unlike the other endpoints above, it is not called from Checkout front-end but from a backend system. It is protected by `manage_project` and `manage_checkout_transactions` access rights of composable commerce OAuth2 token.
+
+#### Endpoint
+
+`POST /operations/transactions`
+
+#### Request Parameters
+
+- cartId: Id of the cart to charge.
+- checkoutTransactionItemId: Id of the checkout payment-transaction item this request is processing. The commercetools Payment created for this charge is linked to this value.
+- amount
+  - centAmount: Amount in the smallest indivisible unit of a currency. For example, 5 EUR is specified as 500 while 5 JPY is specified as 5. It must match the currency and not exceed the outstanding amount of the cart, otherwise the request is rejected.
+  - currencyCode: Currency code compliant to [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)
+- paymentMethodId: Id of the previously stored payment method to charge.
+- idempotencyKey: Key used to make repeated requests for the same charge attempt idempotent, both towards this endpoint and towards Adyen.
+- type: Type of transaction to process. Currently only `Recurring` is supported.
+
+#### Response Parameters
+
+- transactionStatus
+  - state: Result of the transaction. It can be `Pending`, `Failed` or `Completed`. `Pending` means Adyen accepted the charge but has not confirmed it yet - typical of payment methods that are settled asynchronously and may still be confirmed at a later point because it requires time.
+  - paymentId: Id of the commercetools Payment resource created for this charge, when available.
+  - errors: List of errors.
+
+```
+{
+    transactionStatus: {
+        state: "Pending|Failed|Completed",
+        paymentId: "<paymentId>",
+        errors: [{ code: "PaymentRejected", message: "<message>" }]
+    }
+}
 ```
 
 ### Create Apple Pay payment session

--- a/processor/README.md
+++ b/processor/README.md
@@ -480,16 +480,16 @@ Private endpoint used for server-to-server payment processing, for example to ch
 
 - transactionStatus
   - state: Result of the transaction. It can be `Pending`, `Failed` or `Completed`. `Pending` means Adyen accepted the charge but has not confirmed it yet - typical of payment methods that are settled asynchronously and may still be confirmed at a later point because it requires time.
-  - paymentId: Id of the commercetools Payment resource created for this charge, when available.
   - errors: List of errors.
+- paymentId: Id of the commercetools Payment resource created for this charge, when available.
 
 ```
 {
     transactionStatus: {
         state: "Pending|Failed|Completed",
-        paymentId: "<paymentId>",
         errors: [{ code: "PaymentRejected", message: "<message>" }]
-    }
+    },
+    paymentId: "<paymentId>"
 }
 ```
 

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -35,7 +35,6 @@ export const TransactionStatusState = Type.Union([
 export const TransactionResponse = Type.Object({
   transactionStatus: Type.Object({
     state: TransactionStatusState,
-    paymentId: Type.Optional(Type.String()),
     errors: Type.Array(
       Type.Object({
         code: Type.Literal('PaymentRejected'),
@@ -43,6 +42,7 @@ export const TransactionResponse = Type.Object({
       }),
     ),
   }),
+  paymentId: Type.Optional(Type.String()),
 });
 
 export type TransactionDraftDTO = Static<typeof TransactionDraft>;

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -5,12 +5,22 @@ const TransactionTypes = Type.Union([Type.Literal('Recurring')]);
 export const TransactionDraft = Type.Object({
   cartId: Type.String({ format: 'uuid' }),
   checkoutTransactionItemId: Type.String({ format: 'uuid' }),
-  amount: Type.Object({
-    centAmount: Type.Number(),
-    currencyCode: Type.String(),
-  }),
-  paymentMethodId: Type.String({ format: 'uuid' }),
-  idempotencyKey: Type.String(),
+  paymentInterface: Type.Optional(
+    Type.String({
+      format: 'uuid',
+      deprecated: true,
+      description: 'Deprecated: use checkoutTransactionItemId instead.',
+    }),
+  ),
+  amount: Type.Optional(
+    Type.Object({
+      centAmount: Type.Number(),
+      currencyCode: Type.String(),
+    }),
+  ),
+  paymentMethodId: Type.Optional(Type.String({ format: 'uuid' })),
+  idempotencyKey: Type.Optional(Type.String()),
+  futureOrderNumber: Type.Optional(Type.String()),
   type: TransactionTypes,
 });
 

--- a/processor/src/dtos/operations/transaction.dto.ts
+++ b/processor/src/dtos/operations/transaction.dto.ts
@@ -4,21 +4,14 @@ const TransactionTypes = Type.Union([Type.Literal('Recurring')]);
 
 export const TransactionDraft = Type.Object({
   cartId: Type.String({ format: 'uuid' }),
-  paymentInterface: Type.String({ format: 'uuid' }),
   checkoutTransactionItemId: Type.String({ format: 'uuid' }),
-  amount: Type.Optional(
-    Type.Object({
-      centAmount: Type.Number(),
-      currencyCode: Type.String(),
-    }),
-  ),
-  futureOrderNumber: Type.Optional(Type.String()),
-  paymentMethod: Type.Optional(
-    Type.Object({
-      id: Type.String({ format: 'uuid' }),
-    }),
-  ),
-  type: Type.Optional(TransactionTypes),
+  amount: Type.Object({
+    centAmount: Type.Number(),
+    currencyCode: Type.String(),
+  }),
+  paymentMethodId: Type.String({ format: 'uuid' }),
+  idempotencyKey: Type.String(),
+  type: TransactionTypes,
 });
 
 const TransactionStatePending = Type.Literal('Pending', {
@@ -42,6 +35,7 @@ export const TransactionStatusState = Type.Union([
 export const TransactionResponse = Type.Object({
   transactionStatus: Type.Object({
     state: TransactionStatusState,
+    paymentId: Type.Optional(Type.String()),
     errors: Type.Array(
       Type.Object({
         code: Type.Literal('PaymentRejected'),

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -925,16 +925,34 @@ export class AdyenPaymentService extends AbstractPaymentService {
 
     const cartAmount = await this.ctCartService.getPaymentAmount({ cart: ctCart });
 
-    if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
-      throw new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, cartAmount.currencyCode);
+    if (transactionDraft.amount) {
+      if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
+        throw new ErrorInvalidField(
+          'amount.currencyCode',
+          transactionDraft.amount.currencyCode,
+          cartAmount.currencyCode,
+        );
+      }
+
+      if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
+        throw new ErrorInvalidField(
+          'amount.centAmount',
+          String(transactionDraft.amount.centAmount),
+          `<= ${cartAmount.centAmount}`,
+        );
+      }
     }
 
-    if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
-      throw new ErrorInvalidField(
-        'amount.centAmount',
-        String(transactionDraft.amount.centAmount),
-        `<= ${cartAmount.centAmount}`,
-      );
+    if (!transactionDraft.paymentMethodId) {
+      throw new ErrorRequiredField('paymentMethodId', {
+        privateMessage: 'paymentMethodId is not set on the transaction draft',
+        privateFields: {
+          cart: {
+            id: ctCart.id,
+          },
+          checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
+        },
+      });
     }
 
     const paymentMethod = await this.ctPaymentMethodService.get({
@@ -959,7 +977,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       });
     }
 
-    const amountPlanned = transactionDraft.amount;
+    const amountPlanned = transactionDraft.amount ?? cartAmount;
 
     const newlyCreatedPayment = await this.ctPaymentService.createPayment({
       amountPlanned,
@@ -992,6 +1010,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       cart: ctCart,
       payment: newlyCreatedPayment,
       paymentMethod: paymentMethod,
+      futureOrderNumber: transactionDraft.futureOrderNumber,
     });
 
     try {

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -1035,8 +1035,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
             },
           ],
           state: 'Failed',
-          paymentId: updatedPayment.id,
         },
+        paymentId: updatedPayment.id,
       };
     }
 
@@ -1045,8 +1045,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
         transactionStatus: {
           errors: [],
           state: 'Completed',
-          paymentId: updatedPayment.id,
         },
+        paymentId: updatedPayment.id,
       };
     }
 
@@ -1054,8 +1054,8 @@ export class AdyenPaymentService extends AbstractPaymentService {
       transactionStatus: {
         errors: [],
         state: 'Pending',
-        paymentId: updatedPayment.id,
       },
+      paymentId: updatedPayment.id,
     };
   }
 

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -93,7 +93,6 @@ import {
   buildCheckoutTransactionItemId,
   convertAdyenCardBrandToCTFormat,
   convertPaymentMethodFromAdyenFormat,
-  convertPaymentMethodToAdyenFormat,
   isGiftCardSplitPayment,
 } from './converters/helper.converter';
 import { populateInterfaceInteraction, AdyenRequestPayload, AdyenResponsePayload } from './helper.service';
@@ -219,7 +218,6 @@ export class AdyenPaymentService extends AbstractPaymentService {
       'view_api_clients',
       'manage_orders',
       'introspect_oauth_tokens',
-      'manage_checkout_payment_intents',
     ];
 
     if (getStoredPaymentMethodsConfig().enabled) {
@@ -921,26 +919,26 @@ export class AdyenPaymentService extends AbstractPaymentService {
             id: ctCart.id,
           },
           checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
-          paymentInterface: transactionDraft.paymentInterface,
         },
       });
     }
 
-    if (!transactionDraft.paymentMethod) {
-      throw new ErrorRequiredField('paymentMethod', {
-        privateMessage: 'paymentMethod is not provided in the draft',
-        privateFields: {
-          cart: {
-            id: ctCart.id,
-          },
-          checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
-          paymentInterface: transactionDraft.paymentInterface,
-        },
-      });
+    const cartAmount = await this.ctCartService.getPaymentAmount({ cart: ctCart });
+
+    if (transactionDraft.amount.currencyCode !== cartAmount.currencyCode) {
+      throw new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, cartAmount.currencyCode);
+    }
+
+    if (transactionDraft.amount.centAmount > cartAmount.centAmount) {
+      throw new ErrorInvalidField(
+        'amount.centAmount',
+        String(transactionDraft.amount.centAmount),
+        `<= ${cartAmount.centAmount}`,
+      );
     }
 
     const paymentMethod = await this.ctPaymentMethodService.get({
-      id: transactionDraft.paymentMethod.id,
+      id: transactionDraft.paymentMethodId,
       customerId: ctCart.customerId,
       paymentInterface: getStoredPaymentMethodsConfig().config.paymentInterface,
       interfaceAccount: getStoredPaymentMethodsConfig().config.interfaceAccount,
@@ -954,7 +952,6 @@ export class AdyenPaymentService extends AbstractPaymentService {
             id: ctCart.id,
           },
           checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
-          paymentInterface: transactionDraft.paymentInterface,
           paymentMethod: {
             id: paymentMethod.id,
           },
@@ -962,21 +959,17 @@ export class AdyenPaymentService extends AbstractPaymentService {
       });
     }
 
-    // Determine the amount that needs to be payed and setup the payment entity in CT
-    let amountPlanned = transactionDraft.amount;
-    if (!amountPlanned) {
-      amountPlanned = await this.ctCartService.getPaymentAmount({ cart: ctCart });
-    }
+    const amountPlanned = transactionDraft.amount;
 
     const newlyCreatedPayment = await this.ctPaymentService.createPayment({
       amountPlanned,
       checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
       paymentMethodInfo: {
-        paymentInterface: transactionDraft.paymentInterface,
+        paymentInterface: getConfig().paymentInterface,
         token: {
           value: paymentMethod.token.value,
         },
-        ...(paymentMethod.method && { method: convertPaymentMethodToAdyenFormat(paymentMethod.method) }),
+        ...(paymentMethod.method && { method: paymentMethod.method }),
       },
       customer: {
         typeId: 'customer',
@@ -1002,16 +995,12 @@ export class AdyenPaymentService extends AbstractPaymentService {
     });
 
     try {
-      res = await AdyenApi().PaymentsApi.payments(data);
+      res = await AdyenApi().PaymentsApi.payments(data, { idempotencyKey: transactionDraft.idempotencyKey });
     } catch (e) {
       throw wrapAdyenError(e);
     }
 
-    // Handle the response from Adyen
-    const txState = this.convertAdyenResultCode(
-      res.resultCode as PaymentResponse.ResultCodeEnum,
-      this.isActionRequired(res),
-    );
+    const txState = this.convertAdyenResultCode(res.resultCode as PaymentResponse.ResultCodeEnum, false);
 
     const interfaceInteraction = this.buildInterfaceInteraction('CreatePayment', data, res);
 
@@ -1028,7 +1017,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       pspInteractions: interfaceInteraction,
     });
 
-    log.info("Payment authorization processed for 'transaction' stored payment method", {
+    log.info('Payment authorization processed for recurring payment', {
       paymentId: updatedPayment.id,
       interactionId: res.pspReference,
       interfaceId: res.pspReference,
@@ -1046,6 +1035,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
             },
           ],
           state: 'Failed',
+          paymentId: updatedPayment.id,
         },
       };
     }
@@ -1055,6 +1045,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
         transactionStatus: {
           errors: [],
           state: 'Completed',
+          paymentId: updatedPayment.id,
         },
       };
     }
@@ -1063,6 +1054,7 @@ export class AdyenPaymentService extends AbstractPaymentService {
       transactionStatus: {
         errors: [],
         state: 'Pending',
+        paymentId: updatedPayment.id,
       },
     };
   }

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -2708,8 +2708,8 @@ describe('adyen-payment.service', () => {
           transactionStatus: {
             errors: [],
             state: 'Pending',
-            paymentId,
           },
+          paymentId,
         });
       });
     });

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -2408,18 +2408,18 @@ describe('adyen-payment.service', () => {
 
     const adyenTokenId = 'adyen-token-id-value';
 
+    const idempotencyKey = 'idempotency-key-value';
+
     const transactionDraft: TransactionDraftDTO = {
       cartId: 'fcd6bbc4-64a9-48b8-918e-bfa60d3d7495',
       checkoutTransactionItemId: 'ee64746c-327c-4732-b1d2-678ded3c760e',
-      paymentInterface: 'ee64746c-327c-4732-b1d2-678ded3c760e',
       amount: {
         centAmount: 1199,
         currencyCode: 'EUR',
       },
       futureOrderNumber: 'future-order-number',
-      paymentMethod: {
-        id: 'f3850734-0da8-4c57-8009-2425991c12aa',
-      },
+      paymentMethodId: 'f3850734-0da8-4c57-8009-2425991c12aa',
+      idempotencyKey,
       type: 'Recurring',
     };
 
@@ -2476,7 +2476,7 @@ describe('adyen-payment.service', () => {
         );
       });
 
-      test('it should throw an ErrorRequiredField if the no paymentMethod reference is provided', async () => {
+      test('it should throw an ErrorInvalidField if the draft amount currency does not match the cart amount currency', async () => {
         jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
           enabled: true,
           config: {
@@ -2496,14 +2496,49 @@ describe('adyen-payment.service', () => {
           .buildRest<TCartRest>({}) as Cart;
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: 'USD',
+          fractionDigits: 2,
+        });
 
-        const transactionDraftWithoutPaymentMethod: TransactionDraftDTO = {
-          ...transactionDraft,
-          paymentMethod: undefined,
-        };
+        expect(paymentService.handleTransaction(transactionDraft)).rejects.toThrow(
+          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, 'USD'),
+        );
+      });
 
-        expect(paymentService.handleTransaction(transactionDraftWithoutPaymentMethod)).rejects.toThrow(
-          new ErrorRequiredField('paymentMethod'),
+      test('it should throw an ErrorInvalidField if the draft amount is greater than the cart amount', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface,
+            interfaceAccount,
+            supportedPaymentMethodTypes: {
+              scheme: { oneOffPayments: true },
+            },
+          },
+        });
+
+        const cartRandom = CartRest.random()
+          .origin('RecurringOrder')
+          .lineItems([])
+          .customLineItems([])
+          .customerId(customerId)
+          .buildRest<TCartRest>({}) as Cart;
+
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount - 1,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+
+        expect(paymentService.handleTransaction(transactionDraft)).rejects.toThrow(
+          new ErrorInvalidField(
+            'amount.centAmount',
+            String(transactionDraft.amount.centAmount),
+            `<= ${transactionDraft.amount.centAmount - 1}`,
+          ),
         );
       });
 
@@ -2536,6 +2571,11 @@ describe('adyen-payment.service', () => {
         };
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(paymentMethod);
 
         expect(paymentService.handleTransaction(transactionDraft)).rejects.toThrow(new ErrorRequiredField('token'));
@@ -2578,6 +2618,11 @@ describe('adyen-payment.service', () => {
 
         jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(paymentMethod);
 
         jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(paymentRandom);
@@ -2622,17 +2667,19 @@ describe('adyen-payment.service', () => {
           },
           checkoutTransactionItemId: transactionDraft.checkoutTransactionItemId,
           paymentMethodInfo: {
-            paymentInterface: transactionDraft.paymentInterface,
+            paymentInterface: Config.getConfig().paymentInterface,
             token: {
               value: adyenTokenId,
             },
-            method: 'scheme',
+            method: 'card',
           },
           customer: {
             typeId: 'customer',
             id: customerId,
           },
         });
+
+        expect(PaymentsApi.prototype.payments).toHaveBeenCalledWith(expect.anything(), { idempotencyKey });
 
         expect(DefaultCartService.prototype.addPayment).toHaveBeenCalledWith({
           resource: {
@@ -2661,6 +2708,7 @@ describe('adyen-payment.service', () => {
           transactionStatus: {
             errors: [],
             state: 'Pending',
+            paymentId,
           },
         });
       });

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -2476,6 +2476,78 @@ describe('adyen-payment.service', () => {
         );
       });
 
+      test('it should fall back to the cart amount, skipping currency/amount validation, when the draft does not have an amount set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface,
+            interfaceAccount,
+            supportedPaymentMethodTypes: {
+              scheme: { oneOffPayments: true },
+            },
+          },
+        });
+
+        const cartRandom = CartRest.random()
+          .origin('RecurringOrder')
+          .lineItems([])
+          .customLineItems([])
+          .customerId(customerId)
+          .buildRest<TCartRest>({}) as Cart;
+
+        const paymentMethod: PaymentMethod = {
+          id: paymentMethodId,
+          createdAt: '',
+          lastModifiedAt: '',
+          paymentMethodStatus: 'Active',
+          version: 1,
+          default: false,
+          token: {
+            value: adyenTokenId,
+          },
+        };
+
+        const paymentRandom = PaymentRest.random().id(paymentId).buildRest<TPaymentRest>() as Payment;
+
+        const cartAmount = {
+          centAmount: 999,
+          currencyCode: 'USD',
+          fractionDigits: 2,
+        };
+
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue(cartAmount);
+        jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(paymentMethod);
+        jest.spyOn(DefaultPaymentService.prototype, 'createPayment').mockResolvedValue(paymentRandom);
+        jest.spyOn(DefaultCartService.prototype, 'addPayment').mockResolvedValue(cartRandom);
+        jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValueOnce({
+          merchantAccount: merchantReference,
+          shopperReference: customerId,
+          storedPaymentMethods: [
+            {
+              id: adyenTokenId,
+              type: 'scheme',
+              lastFour: '1234',
+              brand: 'visa',
+              expiryMonth: '03',
+              expiryYear: '30',
+            },
+          ],
+        });
+        jest.spyOn(PaymentsApi.prototype, 'payments').mockResolvedValue(mockAdyenCreatePaymentResponse);
+        jest.spyOn(DefaultPaymentService.prototype, 'updatePayment').mockResolvedValue(paymentRandom);
+
+        const transactionDraftWithoutAmount: TransactionDraftDTO = { ...transactionDraft, amount: undefined };
+
+        await paymentService.handleTransaction(transactionDraftWithoutAmount);
+
+        expect(DefaultPaymentService.prototype.createPayment).toHaveBeenCalledWith(
+          expect.objectContaining({
+            amountPlanned: cartAmount,
+          }),
+        );
+      });
+
       test('it should throw an ErrorInvalidField if the draft amount currency does not match the cart amount currency', async () => {
         jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
           enabled: true,
@@ -2539,6 +2611,42 @@ describe('adyen-payment.service', () => {
             String(transactionDraft.amount.centAmount),
             `<= ${transactionDraft.amount.centAmount - 1}`,
           ),
+        );
+      });
+
+      test('it should throw an ErrorRequiredField if the draft does not have a paymentMethodId set', async () => {
+        jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+          enabled: true,
+          config: {
+            paymentInterface,
+            interfaceAccount,
+            supportedPaymentMethodTypes: {
+              scheme: { oneOffPayments: true },
+            },
+          },
+        });
+
+        const cartRandom = CartRest.random()
+          .origin('RecurringOrder')
+          .lineItems([])
+          .customLineItems([])
+          .customerId(customerId)
+          .buildRest<TCartRest>({}) as Cart;
+
+        jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+        jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
+          centAmount: transactionDraft.amount.centAmount,
+          currencyCode: transactionDraft.amount.currencyCode,
+          fractionDigits: 2,
+        });
+
+        const transactionDraftWithoutPaymentMethodId: TransactionDraftDTO = {
+          ...transactionDraft,
+          paymentMethodId: undefined,
+        };
+
+        expect(paymentService.handleTransaction(transactionDraftWithoutPaymentMethodId)).rejects.toThrow(
+          new ErrorRequiredField('paymentMethodId'),
         );
       });
 


### PR DESCRIPTION
https://commercetools.atlassian.net/browse/SCC-3662

Add support to process server to server payments in order to enable Checkout to send payment requests for recurring orders.