### PR TITLE
feat: added applepay to support recurring payments via tokenization

### DIFF
--- a/processor/src/config/stored-payment-methods.config.ts
+++ b/processor/src/config/stored-payment-methods.config.ts
@@ -40,6 +40,10 @@ export const getStoredPaymentMethodsConfig = (): StoredPaymentMethodsConfig => {
           oneOffPayments: false,
           recurringPayments: true,
         },
+        applepay: {
+          oneOffPayments: false,
+          recurringPayments: true,
+        },
       },
     },
   };

--- a/processor/test/config/stored-payment-method.config.spec.ts
+++ b/processor/test/config/stored-payment-method.config.spec.ts
@@ -12,6 +12,10 @@ describe('stored-payment-methods.config', () => {
         oneOffPayments: false,
         recurringPayments: true,
       },
+      applepay: {
+        oneOffPayments: false,
+        recurringPayments: true,
+      },
     });
   });
 });

--- a/processor/test/routes.test/operations.spec.ts
+++ b/processor/test/routes.test/operations.spec.ts
@@ -124,7 +124,7 @@ describe('/operations APIs', () => {
         storedPaymentMethodsConfig: {
           isEnabled: true,
         },
-        methodsAllowedForRecurringPayments: ['scheme', 'googlepay'],
+        methodsAllowedForRecurringPayments: ['scheme', 'googlepay', 'applepay'],
       });
     });
   });


### PR DESCRIPTION
This pull request adds support for Apple Pay as a stored payment method for recurring payments. The changes ensure that Apple Pay is properly configured and tested alongside existing payment methods.

**Stored Payment Methods Configuration**
* Added `applepay` to the `storedPaymentMethodsConfig` with support for recurring payments and no support for one-off payments in `stored-payment-methods.config.ts`.

**Testing and Allowed Methods**
* Updated the configuration test to include `applepay` with the correct payment capabilities in `stored-payment-method.config.spec.ts`.
* Added `applepay` to the list of methods allowed for recurring payments in the operations API test in `operations.spec.ts`.