### PR TITLE
feat: recurring payments listed for a given cart in dev-utils

### DIFF
--- a/enabler/dev-utils/commercestore/css/store.css
+++ b/enabler/dev-utils/commercestore/css/store.css
@@ -314,6 +314,11 @@ body {
 }
 .cs-saved-card:hover { border-color: #6359ff; background: #6359ff06; }
 .cs-saved-card.selected { border-color: #6359ff; background: #6359ff0d; }
+.cs-saved-card--static { cursor: default; justify-content: space-between; }
+.cs-saved-card--static:hover { border-color: #e0e0ee; background: #fff; }
+
+.cs-recurring-list { display: flex; flex-direction: column; gap: 6px; margin-top: 16px; }
+.cs-recurring-method-id { font-size: 11px; color: #999; flex-shrink: 0; }
 
 .cs-saved-card__radio {
   flex-shrink: 0;

--- a/enabler/dev-utils/commercestore/recurring.html
+++ b/enabler/dev-utils/commercestore/recurring.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>commercestore — Recurring</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"
+      integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous" />
+    <link rel="stylesheet" href="/dev-utils/commercestore/css/store.css" />
+    <script>
+      window.__VITE_CTP_AUTH_URL__ = !"%VITE_CTP_AUTH_URL%".startsWith("%") && "%VITE_CTP_AUTH_URL%";
+      window.__VITE_CTP_API_URL__ = !"%VITE_CTP_API_URL%".startsWith("%") && "%VITE_CTP_API_URL%";
+      window.__VITE_CTP_SESSION_URL__ = !"%VITE_CTP_SESSION_URL%".startsWith("%") && "%VITE_CTP_SESSION_URL%";
+      window.__VITE_CTP_CLIENT_ID__ = !"%VITE_CTP_CLIENT_ID%".startsWith("%") && "%VITE_CTP_CLIENT_ID%";
+      window.__VITE_CTP_CLIENT_SECRET__ = !"%VITE_CTP_CLIENT_SECRET%".startsWith("%") && "%VITE_CTP_CLIENT_SECRET%";
+      window.__VITE_CTP_PROJECT_KEY__ = !"%VITE_CTP_PROJECT_KEY%".startsWith("%") && "%VITE_CTP_PROJECT_KEY%";
+      window.__VITE_PROCESSOR_URL__ = !"%VITE_PROCESSOR_URL%".startsWith("%") && "%VITE_PROCESSOR_URL%";
+      window.__VITE_PAYMENT_INTERFACE__ = (!"%VITE_PAYMENT_INTERFACE%".startsWith("%") && "%VITE_PAYMENT_INTERFACE%") || "checkout-adyen";
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/dev-utils/commercestore/src/recurring.tsx"></script>
+  </body>
+</html>

--- a/enabler/dev-utils/commercestore/src/RecurringApp.tsx
+++ b/enabler/dev-utils/commercestore/src/RecurringApp.tsx
@@ -1,0 +1,109 @@
+import { useState, useCallback } from 'react';
+import Header from './components/Header.tsx';
+import ToastContainer from './components/Toast.tsx';
+import Spinner from './components/Spinner.tsx';
+import { useToast } from './hooks/useToast.ts';
+import { getSessionId } from './api/ct.ts';
+import { fetchRecurringStoredPaymentMethods } from './api/processor.ts';
+import { WALLET_METHODS } from '../../wallet-methods.ts';
+import type { StoredPaymentMethod } from './types.ts';
+
+function RecurringMethodItem({ method }: { method: StoredPaymentMethod }) {
+  const brand = method.displayOptions?.brand?.key ?? '';
+  const last4 = method.displayOptions?.endDigits;
+  const walletLabel = WALLET_METHODS[method.type]?.label;
+  const exp = method.displayOptions?.expiryMonth && method.displayOptions?.expiryYear
+    ? `${String(method.displayOptions.expiryMonth).padStart(2, '0')}/${String(method.displayOptions.expiryYear).slice(-2)}`
+    : null;
+
+  return (
+    <div className="cs-saved-card cs-saved-card--static">
+      <span className="cs-saved-card__info">
+        <span className="cs-saved-card__main">
+          {walletLabel && <span className="cs-saved-card__wallet">{walletLabel}</span>}
+          {brand ? (
+            <span className={`cs-saved-card__brand cs-saved-card__brand--${brand.toLowerCase()}`}>{brand}</span>
+          ) : !walletLabel ? (
+            <span className={`cs-saved-card__brand cs-saved-card__brand--${method.type.toLowerCase()}`}>{method.type}</span>
+          ) : null}
+          <span className="cs-saved-card__number">•••• {last4 ?? '????'}</span>
+          {exp && <span className="cs-saved-card__exp">{exp}</span>}
+        </span>
+        {method.isDefault && <span className="cs-saved-card__default">Default</span>}
+      </span>
+      <code className="cs-recurring-method-id">{method.id}</code>
+    </div>
+  );
+}
+
+export default function RecurringApp() {
+  const [cartId, setCartId] = useState('');
+  const [methods, setMethods] = useState<StoredPaymentMethod[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const { toasts, addToast, removeToast } = useToast();
+
+  const handleLoad = useCallback(async () => {
+    if (!cartId) return;
+    setLoading(true);
+    setLoaded(false);
+    try {
+      const sessionId = await getSessionId(cartId);
+      const result = await fetchRecurringStoredPaymentMethods(sessionId);
+      setMethods(result);
+      setLoaded(true);
+    } catch (e) {
+      addToast('error', (e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [cartId, addToast]);
+
+  return (
+    <>
+      <Header active="Recurring" />
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+
+      <div className="cs-page">
+        <div className="cs-page-header">
+          <h4>Recurring Payment Methods</h4>
+          <p className="text-muted">
+            Lists the stored payment methods allowed for recurring payments for a cart's customer — separate from
+            the one-off methods shown during checkout.
+          </p>
+        </div>
+
+        <div className="cs-cart-input-row">
+          <label className="cs-cart-label">Cart ID</label>
+          <div className="cs-cart-input-group">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="Paste a cart ID whose customer has a stored payment method"
+              value={cartId}
+              onChange={e => setCartId(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && cartId && handleLoad()}
+            />
+            <button className="btn btn-primary" onClick={handleLoad} disabled={!cartId || loading}>
+              {loading ? 'Loading...' : 'Load'}
+            </button>
+          </div>
+        </div>
+
+        {loading && <Spinner text="Loading recurring payment methods…" />}
+
+        {!loading && loaded && (
+          methods.length > 0 ? (
+            <div className="cs-recurring-list">
+              {methods.map(m => <RecurringMethodItem key={m.id} method={m} />)}
+            </div>
+          ) : (
+            <p className="cs-sidebar-empty">
+              No payment methods allowed for recurring payments were found for this cart's customer.
+            </p>
+          )
+        )}
+      </div>
+    </>
+  );
+}

--- a/enabler/dev-utils/commercestore/src/api/processor.ts
+++ b/enabler/dev-utils/commercestore/src/api/processor.ts
@@ -1,7 +1,22 @@
 import { getCtpToken, getJwtToken } from './ct.ts';
-import type { PaymentMethod } from '../types.ts';
+import type { PaymentMethod, StoredPaymentMethod } from '../types.ts';
 
 const processorUrl = (): string => window.__VITE_PROCESSOR_URL__;
+
+export async function fetchRecurringStoredPaymentMethods(sessionId: string): Promise<StoredPaymentMethod[]> {
+  const res = await fetch(`${processorUrl()}/stored-payment-methods?recurring=true`, {
+    headers: {
+      'X-Session-Id': sessionId,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(err.message || 'Failed to fetch recurring stored payment methods');
+  }
+  const data = await res.json() as { storedPaymentMethods?: StoredPaymentMethod[] };
+  return data.storedPaymentMethods ?? [];
+}
 
 export async function fetchPaymentMethods(): Promise<{
   components: PaymentMethod[];

--- a/enabler/dev-utils/commercestore/src/components/Header.tsx
+++ b/enabler/dev-utils/commercestore/src/components/Header.tsx
@@ -2,6 +2,7 @@ const NAV = [
   { href: '/dev-utils/commercestore/index.html', label: 'Checkout' },
   { href: '/dev-utils/commercestore/express.html', label: 'Express' },
   { href: '/dev-utils/commercestore/payments.html', label: 'Payments' },
+  { href: '/dev-utils/commercestore/recurring.html', label: 'Recurring' },
   { href: '/dev-utils/commercestore/admin.html', label: 'Admin' },
 ];
 

--- a/enabler/dev-utils/commercestore/src/components/checkout/ComponentsTab.tsx
+++ b/enabler/dev-utils/commercestore/src/components/checkout/ComponentsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useEffect, type RefObject } from 'react';
 import { useAdyenMount } from '../../hooks/useAdyenMount.ts';
 import { usePaymentAvailability } from '../../hooks/usePaymentAvailability.ts';
+import { WALLET_METHODS } from '../../../../wallet-methods.ts';
 import type { EnablerInstance, MountableComponent, PaymentMethod, StoredPaymentMethod, CheckoutResult } from '../../types.ts';
 
 interface PaymentMethodItemProps {
@@ -35,6 +36,7 @@ interface SavedMethodItemProps {
 function SavedMethodItem({ method, selected, onClick }: SavedMethodItemProps) {
   const brand = method.displayOptions?.brand?.key ?? '';
   const last4 = method.displayOptions?.endDigits;
+  const walletLabel = WALLET_METHODS[method.type]?.label;
   const exp = method.displayOptions?.expiryMonth && method.displayOptions?.expiryYear
     ? `${String(method.displayOptions.expiryMonth).padStart(2, '0')}/${String(method.displayOptions.expiryYear).slice(-2)}`
     : null;
@@ -45,7 +47,7 @@ function SavedMethodItem({ method, selected, onClick }: SavedMethodItemProps) {
       <span className={`cs-saved-card__radio ${selected ? 'selected' : ''}`} />
       <span className="cs-saved-card__info">
         <span className="cs-saved-card__main">
-          {method.type === 'googlepay' && <span className="cs-saved-card__wallet">G Pay</span>}
+          {walletLabel && <span className="cs-saved-card__wallet">{walletLabel}</span>}
           {brand && <span className={`cs-saved-card__brand cs-saved-card__brand--${brand.toLowerCase()}`}>{brand}</span>}
           <span className="cs-saved-card__number">•••• {last4 ?? '????'}</span>
           {exp && <span className="cs-saved-card__exp">{exp}</span>}

--- a/enabler/dev-utils/commercestore/src/hooks/useCheckout.ts
+++ b/enabler/dev-utils/commercestore/src/hooks/useCheckout.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { getCartById, getSessionId } from '../api/ct.ts';
 import { fetchPaymentMethods } from '../api/processor.ts';
+import { WALLET_METHODS } from '../../../wallet-methods.ts';
 import type {
   CtCart,
   EnablerInstance,
@@ -76,7 +77,7 @@ export function useCheckout(): {
       setDropinMethods(methodsData.dropins);
 
       if (storedEnabled && cartData.customerId) {
-        const stored = await instance.getStoredPaymentMethods({ allowedMethodTypes: ['card', 'googlepay'] }).catch(() => ({ storedPaymentMethods: [] }));
+        const stored = await instance.getStoredPaymentMethods({ allowedMethodTypes: ['card', ...Object.keys(WALLET_METHODS)] }).catch(() => ({ storedPaymentMethods: [] }));
         console.log('[useCheckout] getStoredPaymentMethods raw:', JSON.stringify(stored, null, 2));
         setSavedMethods(stored.storedPaymentMethods ?? []);
       }

--- a/enabler/dev-utils/commercestore/src/recurring.tsx
+++ b/enabler/dev-utils/commercestore/src/recurring.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client';
+import RecurringApp from './RecurringApp.tsx';
+
+createRoot(document.getElementById('root')!).render(<RecurringApp />);

--- a/enabler/dev-utils/wallet-methods.ts
+++ b/enabler/dev-utils/wallet-methods.ts
@@ -1,0 +1,10 @@
+/**
+ * Wallet payment method types recognized by the dev-utils UI, keyed by the type value the
+ * enabler/processor use. Shared so every place that needs to whitelist which stored payment
+ * method types are wallets (either for display or for an allow-list) stays in sync from a
+ * single source.
+ */
+export const WALLET_METHODS: Record<string, { label: string }> = {
+  googlepay: { label: 'G Pay' },
+  applepay: { label: 'Apple Pay' },
+};

--- a/processor/src/routes/adyen-payment.route.ts
+++ b/processor/src/routes/adyen-payment.route.ts
@@ -231,13 +231,13 @@ export const adyenPaymentRoutes = async (
     },
   );
 
-  fastify.get<{ Querystring: { recurring?: string } }>(
+  fastify.get<{ Querystring: { withRecurring?: string } }>(
     '/stored-payment-methods',
     {
       preHandler: [opts.sessionHeaderAuthHook.authenticate()],
       schema: {
         querystring: Type.Object({
-          recurring: Type.Optional(
+          withRecurring: Type.Optional(
             Type.String({
               description: 'Pass "true" to list methods allowed for recurring payments instead of one-off payments.',
             }),
@@ -249,7 +249,9 @@ export const adyenPaymentRoutes = async (
       },
     },
     async (request, reply) => {
-      const res = await opts.paymentService.getStoredPaymentMethods({ recurring: request.query.recurring === 'true' });
+      const res = await opts.paymentService.getStoredPaymentMethods({
+        withRecurring: request.query.withRecurring === 'true',
+      });
       reply.code(200).send(res);
     },
   );

--- a/processor/src/routes/adyen-payment.route.ts
+++ b/processor/src/routes/adyen-payment.route.ts
@@ -231,18 +231,25 @@ export const adyenPaymentRoutes = async (
     },
   );
 
-  fastify.get(
+  fastify.get<{ Querystring: { recurring?: string } }>(
     '/stored-payment-methods',
     {
       preHandler: [opts.sessionHeaderAuthHook.authenticate()],
       schema: {
+        querystring: Type.Object({
+          recurring: Type.Optional(
+            Type.String({
+              description: 'Pass "true" to list methods allowed for recurring payments instead of one-off payments.',
+            }),
+          ),
+        }),
         response: {
           200: StoredPaymentMethodsResponseSchema,
         },
       },
     },
-    async (_, reply) => {
-      const res = await opts.paymentService.getStoredPaymentMethods();
+    async (request, reply) => {
+      const res = await opts.paymentService.getStoredPaymentMethods({ recurring: request.query.recurring === 'true' });
       reply.code(200).send(res);
     },
   );

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -1121,14 +1121,17 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * `createdAt`, `default`). Any Adyen token without a matching record is an "orphan" and gets
    * persisted on the fly, within this same call, by reconcileOrphanAdyenToken().
    */
-  async getStoredPaymentMethods(): Promise<StoredPaymentMethodsResponse> {
+  async getStoredPaymentMethods(opts: { recurring?: boolean } = {}): Promise<StoredPaymentMethodsResponse> {
     const customerId = await this.getCustomerIdFromCart();
     const { paymentInterface, interfaceAccount, supportedPaymentMethodTypes } = getStoredPaymentMethodsConfig().config;
 
-    // The payment method should be displayed in the stored payment methods list if it is supported and one-off payments are allowed for that method.
-    // Methods that only support recurring payments, should not be displayed in the stored payment methods list.
+    // By default the payment method is displayed in the stored payment methods list if it is
+    // supported and one-off payments are allowed for that method. Pass `recurring: true` to
+    // instead list the methods that are allowed to be used for a recurring order's future charges.
     const shouldShowStoredPaymentMethod = (method: string) => {
-      return supportedPaymentMethodTypes[method]?.oneOffPayments;
+      return opts.recurring
+        ? supportedPaymentMethodTypes[method]?.recurringPayments
+        : supportedPaymentMethodTypes[method]?.oneOffPayments;
     };
 
     // Fetched in parallel: neither call depends on the other's result.

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -1121,15 +1121,15 @@ export class AdyenPaymentService extends AbstractPaymentService {
    * `createdAt`, `default`). Any Adyen token without a matching record is an "orphan" and gets
    * persisted on the fly, within this same call, by reconcileOrphanAdyenToken().
    */
-  async getStoredPaymentMethods(opts: { recurring?: boolean } = {}): Promise<StoredPaymentMethodsResponse> {
+  async getStoredPaymentMethods(opts: { withRecurring?: boolean } = {}): Promise<StoredPaymentMethodsResponse> {
     const customerId = await this.getCustomerIdFromCart();
     const { paymentInterface, interfaceAccount, supportedPaymentMethodTypes } = getStoredPaymentMethodsConfig().config;
 
     // By default the payment method is displayed in the stored payment methods list if it is
-    // supported and one-off payments are allowed for that method. Pass `recurring: true` to
+    // supported and one-off payments are allowed for that method. Pass `withRecurring: true` to
     // instead list the methods that are allowed to be used for a recurring order's future charges.
     const shouldShowStoredPaymentMethod = (method: string) => {
-      return opts.recurring
+      return opts.withRecurring
         ? supportedPaymentMethodTypes[method]?.recurringPayments
         : supportedPaymentMethodTypes[method]?.oneOffPayments;
     };

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -1793,6 +1793,89 @@ describe('adyen-payment.service', () => {
       });
     });
 
+    test('should only include methods that support recurringPayments when recurring: true is passed', async () => {
+      const merchantAccount = 'merchantAccount';
+      const customerId = '12303506-396c-4163-9193-11115c10fc2e';
+      const paymentInterface = 'adyen-payment-interface';
+      const interfaceAccount = 'adyen-interface-account';
+      const adyenToken = 'adyen-token-value-123';
+
+      jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+        enabled: true,
+        config: {
+          paymentInterface,
+          interfaceAccount,
+          supportedPaymentMethodTypes: {
+            scheme: { oneOffPayments: false, recurringPayments: true },
+          },
+        },
+      });
+
+      const cartRandom = CartRest.random()
+        .lineItems([])
+        .customLineItems([])
+        .customerId(customerId)
+        .buildRest<TCartRest>({}) as Cart;
+
+      jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValueOnce({
+        merchantAccount,
+        shopperReference: customerId,
+        storedPaymentMethods: [
+          {
+            id: adyenToken,
+            type: 'scheme',
+            lastFour: '1234',
+            brand: 'visa',
+            expiryMonth: '03',
+            expiryYear: '30',
+          },
+        ],
+      });
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValueOnce(cartRandom);
+      jest.spyOn(DefaultPaymentMethodService.prototype, 'find').mockResolvedValueOnce({
+        count: 0,
+        limit: 100,
+        offset: 0,
+        results: [
+          {
+            id: 'd85435f2-2628-457f-8b8e-1a567da30a8d',
+            customer: { id: customerId, typeId: 'customer' },
+            token: { value: adyenToken },
+            paymentInterface,
+            interfaceAccount,
+            method: 'card',
+            createdAt: '',
+            lastModifiedAt: '',
+            default: false,
+            paymentMethodStatus: 'Active',
+            version: 1,
+          },
+        ],
+      });
+
+      // Without recurring: true, oneOffPayments: false excludes it (already covered elsewhere);
+      // with recurring: true, recurringPayments: true includes it.
+      const result = await paymentService.getStoredPaymentMethods({ recurring: true });
+
+      expect(result).toStrictEqual({
+        storedPaymentMethods: [
+          {
+            id: 'd85435f2-2628-457f-8b8e-1a567da30a8d',
+            createdAt: '',
+            isDefault: false,
+            token: adyenToken,
+            type: 'card',
+            displayOptions: {
+              brand: { key: 'Visa' },
+              endDigits: '1234',
+              expiryMonth: 3,
+              expiryYear: 30,
+            },
+          },
+        ],
+      });
+    });
+
     test('should create a commercetools payment-method for an orphan Adyen token with default: false, without ever calling update()', async () => {
       const customerId = '12303506-396c-4163-9193-11115c10fc2e';
       const methodType = 'scheme';

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -1855,7 +1855,7 @@ describe('adyen-payment.service', () => {
 
       // Without recurring: true, oneOffPayments: false excludes it (already covered elsewhere);
       // with recurring: true, recurringPayments: true includes it.
-      const result = await paymentService.getStoredPaymentMethods({ recurring: true });
+      const result = await paymentService.getStoredPaymentMethods({ withRecurring: true });
 
       expect(result).toStrictEqual({
         storedPaymentMethods: [
@@ -2712,7 +2712,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true },
+              scheme: { oneOffPayments: true, recurringPayments: true},
             },
           },
         });
@@ -2798,13 +2798,13 @@ describe('adyen-payment.service', () => {
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
+          centAmount: transactionDraft.amount!.centAmount,
           currencyCode: 'USD',
           fractionDigits: 2,
         });
 
         expect(paymentService.handleTransaction(transactionDraft)).rejects.toThrow(
-          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount.currencyCode, 'USD'),
+          new ErrorInvalidField('amount.currencyCode', transactionDraft.amount!.currencyCode, 'USD'),
         );
       });
 
@@ -2815,7 +2815,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true },
+              scheme: { oneOffPayments: true, recurringPayments: true},
             },
           },
         });
@@ -2829,16 +2829,16 @@ describe('adyen-payment.service', () => {
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount - 1,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount - 1,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
 
         expect(paymentService.handleTransaction(transactionDraft)).rejects.toThrow(
           new ErrorInvalidField(
             'amount.centAmount',
-            String(transactionDraft.amount.centAmount),
-            `<= ${transactionDraft.amount.centAmount - 1}`,
+            String(transactionDraft.amount!.centAmount),
+            `<= ${transactionDraft.amount!.centAmount - 1}`,
           ),
         );
       });
@@ -2850,7 +2850,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true },
+              scheme: { oneOffPayments: true, recurringPayments: true},
             },
           },
         });
@@ -2864,8 +2864,8 @@ describe('adyen-payment.service', () => {
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
 
@@ -2909,8 +2909,8 @@ describe('adyen-payment.service', () => {
 
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(paymentMethod);
@@ -2956,8 +2956,8 @@ describe('adyen-payment.service', () => {
         jest.spyOn(FastifyContext, 'getProcessorUrlFromContext').mockReturnValue('http://127.0.0.1');
         jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
         jest.spyOn(DefaultCartService.prototype, 'getPaymentAmount').mockResolvedValue({
-          centAmount: transactionDraft.amount.centAmount,
-          currencyCode: transactionDraft.amount.currencyCode,
+          centAmount: transactionDraft.amount!.centAmount,
+          currencyCode: transactionDraft.amount!.currencyCode,
           fractionDigits: 2,
         });
         jest.spyOn(DefaultPaymentMethodService.prototype, 'get').mockResolvedValue(paymentMethod);

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -2712,7 +2712,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true, recurringPayments: true},
+              scheme: { oneOffPayments: true, recurringPayments: true },
             },
           },
         });
@@ -2815,7 +2815,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true, recurringPayments: true},
+              scheme: { oneOffPayments: true, recurringPayments: true },
             },
           },
         });
@@ -2850,7 +2850,7 @@ describe('adyen-payment.service', () => {
             paymentInterface,
             interfaceAccount,
             supportedPaymentMethodTypes: {
-              scheme: { oneOffPayments: true, recurringPayments: true},
+              scheme: { oneOffPayments: true, recurringPayments: true },
             },
           },
         });


### PR DESCRIPTION
JIRA- [SCC-3999](https://commercetools.atlassian.net/browse/SCC-3999)
This pull request introduces a new "Recurring Payment Methods" feature to the commercestore dev-utils UI, allowing users to view payment methods that are eligible for recurring payments. It also generalizes wallet payment method handling and improves backend support for filtering stored payment methods by recurring eligibility.

**Recurring Payment Methods UI:**
- Added a new page (`recurring.html` and supporting React components) that lets users input a cart ID and view recurring-eligible stored payment methods for the associated customer. [[1]](diffhunk://#diff-97cfe0922ac8e860fd1e2fc70b17db5e991319f60619677a2752af4e58946180R1-R25) [[2]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0R1-R109) [[3]](diffhunk://#diff-edf94413a3eb8f9de039bc722f7d1298a316241021c5c036bf6565a14a6196c1R1-R4)
- Updated the navigation header to include a link to the new Recurring page.

**Wallet Payment Methods Generalization:**
- Introduced a centralized `WALLET_METHODS` mapping for wallet-type payment methods, replacing hardcoded logic for Google Pay and supporting future wallet types. Updated all relevant UI and logic to use this mapping. [[1]](diffhunk://#diff-5eefabde0bbe42ff521b79278523d03862a66cfb10fa71691e755f89d327198aR1-R10) [[2]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fR4) [[3]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fR39) [[4]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fL48-R50) [[5]](diffhunk://#diff-20c4064e8534705ad283a13148fed463a8f70221c3e5b111039937e6f3b03480R4) [[6]](diffhunk://#diff-20c4064e8534705ad283a13148fed463a8f70221c3e5b111039937e6f3b03480L79-R80)

**Backend and API Enhancements:**
- Extended the `/stored-payment-methods` API (and its service layer) to accept a `recurring=true` query parameter, returning only methods eligible for recurring payments. [[1]](diffhunk://#diff-7bb475c1e79b38620a07c4c63d34bf6fd967d0adf9d6e6faacd3504dbe54b4d6L234-R252) [[2]](diffhunk://#diff-6d406fe8ec80e408fadfcbf75214a060c7e2441e2e51d6a1478be03dd8c0b5a4L1124-R1134)
- Added a new API function in the dev-utils frontend to fetch recurring stored payment methods.

**Testing:**
- Added a test case to ensure that only methods supporting recurring payments are returned when the `recurring` option is used.

**Styling:**
- Added new CSS classes for the recurring payment methods list and static card display.

[SCC-3999]: https://commercetools.atlassian.net/browse/SCC-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ