### PR TITLE
feat: #3 tokenize bancontact

### DIFF
--- a/enabler/dev-utils/commercestore/src/RecurringApp.tsx
+++ b/enabler/dev-utils/commercestore/src/RecurringApp.tsx
@@ -4,11 +4,19 @@ import ToastContainer from './components/Toast.tsx';
 import Spinner from './components/Spinner.tsx';
 import { useToast } from './hooks/useToast.ts';
 import { getSessionId } from './api/ct.ts';
-import { fetchRecurringStoredPaymentMethods } from './api/processor.ts';
+import { deleteStoredPaymentMethod, fetchRecurringStoredPaymentMethods } from './api/processor.ts';
 import { METHOD_LABELS, METHODS_WITH_NO_CARDS } from '../../method-labels.ts';
 import type { StoredPaymentMethod } from './types.ts';
 
-function RecurringMethodItem({ method }: { method: StoredPaymentMethod }) {
+function RecurringMethodItem({
+  method,
+  onRemove,
+  removing,
+}: {
+  method: StoredPaymentMethod;
+  onRemove: (id: string) => void;
+  removing: boolean;
+}) {
   const brand = method.displayOptions?.brand?.key ?? '';
   const showBrandBadge = brand && brand !== 'Unknown';
   const last4 = method.displayOptions?.endDigits;
@@ -34,15 +42,20 @@ function RecurringMethodItem({ method }: { method: StoredPaymentMethod }) {
         {method.isDefault && <span className="cs-saved-card__default">Default</span>}
       </span>
       <code className="cs-recurring-method-id">{method.id}</code>
+      <button className="cs-remove-saved-btn" onClick={() => onRemove(method.id)} disabled={removing}>
+        {removing ? 'Removing…' : 'Remove'}
+      </button>
     </div>
   );
 }
 
 export default function RecurringApp() {
   const [cartId, setCartId] = useState('');
+  const [sessionId, setSessionId] = useState('');
   const [methods, setMethods] = useState<StoredPaymentMethod[]>([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
   const { toasts, addToast, removeToast } = useToast();
 
   const handleLoad = useCallback(async () => {
@@ -50,8 +63,9 @@ export default function RecurringApp() {
     setLoading(true);
     setLoaded(false);
     try {
-      const sessionId = await getSessionId(cartId);
-      const result = await fetchRecurringStoredPaymentMethods(sessionId);
+      const newSessionId = await getSessionId(cartId);
+      const result = await fetchRecurringStoredPaymentMethods(newSessionId);
+      setSessionId(newSessionId);
       setMethods(result);
       setLoaded(true);
     } catch (e) {
@@ -60,6 +74,18 @@ export default function RecurringApp() {
       setLoading(false);
     }
   }, [cartId, addToast]);
+
+  const handleRemove = useCallback(async (id: string) => {
+    setRemovingId(id);
+    try {
+      await deleteStoredPaymentMethod(id, sessionId);
+      setMethods(current => current.filter(m => m.id !== id));
+    } catch (e) {
+      addToast('error', (e as Error).message);
+    } finally {
+      setRemovingId(null);
+    }
+  }, [sessionId, addToast]);
 
   return (
     <>
@@ -97,7 +123,9 @@ export default function RecurringApp() {
         {!loading && loaded && (
           methods.length > 0 ? (
             <div className="cs-recurring-list">
-              {methods.map(m => <RecurringMethodItem key={m.id} method={m} />)}
+              {methods.map(m => (
+                <RecurringMethodItem key={m.id} method={m} onRemove={handleRemove} removing={removingId === m.id} />
+              ))}
             </div>
           ) : (
             <p className="cs-sidebar-empty">

--- a/enabler/dev-utils/commercestore/src/api/processor.ts
+++ b/enabler/dev-utils/commercestore/src/api/processor.ts
@@ -18,6 +18,19 @@ export async function fetchRecurringStoredPaymentMethods(sessionId: string): Pro
   return data.storedPaymentMethods ?? [];
 }
 
+export async function deleteStoredPaymentMethod(id: string, sessionId: string): Promise<void> {
+  const res = await fetch(`${processorUrl()}/stored-payment-methods/${id}`, {
+    method: 'DELETE',
+    headers: {
+      'X-Session-Id': sessionId,
+    },
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(err.message || 'Failed to delete stored payment method');
+  }
+}
+
 export async function fetchPaymentMethods(): Promise<{
   components: PaymentMethod[];
   dropins: PaymentMethod[];

--- a/processor/src/config/stored-payment-methods.config.ts
+++ b/processor/src/config/stored-payment-methods.config.ts
@@ -75,6 +75,14 @@ export const getStoredPaymentMethodsConfig = (): StoredPaymentMethodsConfig => {
           oneOffPayments: false,
           recurringPayments: true,
         },
+        bcmc: {
+          oneOffPayments: false,
+          recurringPayments: true,
+        },
+        bcmc_mobile: {
+          oneOffPayments: false,
+          recurringPayments: true,
+        },
       },
     },
   };

--- a/processor/src/config/stored-payment-methods.config.ts
+++ b/processor/src/config/stored-payment-methods.config.ts
@@ -67,6 +67,14 @@ export const getStoredPaymentMethodsConfig = (): StoredPaymentMethodsConfig => {
           recurringPayments: true,
           tokenizationAllowedCountries: ['AU', 'NZ'],
         },
+        bcmc: {
+          oneOffPayments: false,
+          recurringPayments: true,
+        },
+        bcmc_mobile: {
+          oneOffPayments: false,
+          recurringPayments: true,
+        },
       },
     },
   };

--- a/processor/src/services/adyen-payment.service.ts
+++ b/processor/src/services/adyen-payment.service.ts
@@ -95,9 +95,9 @@ import {
   convertPaymentMethodFromAdyenFormat,
   convertPaymentMethodToAdyenFormat,
   extractCardBrand,
-  extractWalletTypeFromBrand,
+  extractCollapsedTypeFromBrand,
+  isCollapsedTypePayment,
   isGiftCardSplitPayment,
-  isWalletPayment,
 } from './converters/helper.converter';
 import { populateInterfaceInteraction, AdyenRequestPayload, AdyenResponsePayload } from './helper.service';
 import {
@@ -1219,13 +1219,14 @@ export class AdyenPaymentService extends AbstractPaymentService {
         expiryYear: adyenToken.expiryYear ? Number(adyenToken.expiryYear) : undefined,
       },
     };
-    // Check if the AdyenToken is for a wallet payment method
-    // If so, the type of the payment method should be the wallet type instead of 'scheme/card'
-    // For wallet type, the brand is returned as 'amex_googlepay', etc while the type is 'scheme'
-    if (adyenToken.brand && isWalletPayment(adyenToken.brand)) {
-      const walletType = extractWalletTypeFromBrand(adyenToken.brand);
-      if (walletType) {
-        mappedResponse.type = walletType;
+    // Adyen collapses some payment methods (e.g. Google Pay, Bancontact card) into a generic
+    // 'scheme' token, encoding the real payment method type in the brand instead (e.g.
+    // 'amex_googlepay', 'bcmc'). If so, the type of the payment method should be that real type
+    // instead of 'scheme/card'.
+    if (adyenToken.brand && isCollapsedTypePayment(adyenToken.brand)) {
+      const collapsedType = extractCollapsedTypeFromBrand(adyenToken.brand);
+      if (collapsedType) {
+        mappedResponse.type = convertPaymentMethodFromAdyenFormat(collapsedType);
       }
     }
     return mappedResponse;
@@ -1245,13 +1246,13 @@ export class AdyenPaymentService extends AbstractPaymentService {
     try {
       // Always created with default: false
       const customFields = this.getPaymentMethodCustomFieldsDraft(adyenToken);
-      const walletType = extractWalletTypeFromBrand(adyenToken.brand);
+      const collapsedType = extractCollapsedTypeFromBrand(adyenToken.brand);
       const createdPaymentMethod = await this.ctPaymentMethodService.save({
         customerId,
         token: adyenToken.id || '',
         paymentInterface,
         interfaceAccount,
-        method: convertPaymentMethodFromAdyenFormat(walletType ?? (adyenToken.type as string)),
+        method: convertPaymentMethodFromAdyenFormat(collapsedType ?? (adyenToken.type as string)),
         customFields,
       });
 

--- a/processor/src/services/converters/helper.converter.ts
+++ b/processor/src/services/converters/helper.converter.ts
@@ -435,47 +435,53 @@ export const convertAdyenCardBrandToCTFormat = (brand?: string): string => {
   return ADYEN_CARD_BRAND_TO_CT_MAPPING[brand] ?? 'Unknown';
 };
 
-const WALLET_BRAND_SUFFIXES: Record<string, string> = {
-  googlepay: '_googlepay',
+type CollapsedTypeBrandPattern = {
+  suffix: string;
+  // True when the suffix wraps a real card brand that should be revealed once stripped, e.g.
+  // "visa" from "visa_googlepay". False when the brand *is* the method's own identity with no
+  // separate underlying card brand to reveal, e.g. Bancontact's "bcmc".
+  revealsUnderlyingCardBrand: boolean;
+};
+
+// Adyen tokenizes some payment methods as a generic "scheme" token, encoding the original payment
+// method type in the brand string instead of a distinct `type`.
+const COLLAPSED_TYPE_BRAND_PATTERNS: Record<string, CollapsedTypeBrandPattern> = {
+  googlepay: { suffix: '_googlepay', revealsUnderlyingCardBrand: true },
+  bcmc: { suffix: 'bcmc', revealsUnderlyingCardBrand: false },
 };
 
 /**
- * Adyen tokenizes wallet payments (e.g. Google Pay) as a generic "scheme" token, encoding the
- * original wallet in the brand string instead, e.g. "amex_googlepay". Returns the wallet's
- * payment method type (e.g. "googlepay") if the brand carries one, otherwise undefined.
+ * Returns the real payment method type encoded in the brand (e.g. "googlepay" from
+ * "amex_googlepay", or "bcmc" from "bcmc"), or undefined if the brand carries none.
  */
-export const extractWalletTypeFromBrand = (brand?: string): string | undefined => {
+export const extractCollapsedTypeFromBrand = (brand?: string): string | undefined => {
   if (!brand) {
     return undefined;
   }
 
-  return Object.entries(WALLET_BRAND_SUFFIXES).find(([, suffix]) => brand.endsWith(suffix))?.[0];
+  return Object.entries(COLLAPSED_TYPE_BRAND_PATTERNS).find(([, pattern]) => brand.endsWith(pattern.suffix))?.[0];
 };
 
 /**
- *
- * @param brand The Adyen brand string to verify if it is for a wallet payment (e.g. Google Pay)
- * @returns true if the Adyen brand is for a wallet payment, otherwise false
+ * @param brand The Adyen brand string to verify if it is for a type-collapsed payment method (e.g. Google Pay, Bancontact card)
+ * @returns true if the Adyen brand carries a collapsed payment method type, otherwise false
  */
-export const isWalletPayment = (brand?: string): boolean => {
-  if (!brand) {
-    return false;
-  }
-
-  return Object.values(WALLET_BRAND_SUFFIXES).some((suffix) => brand.endsWith(suffix));
+export const isCollapsedTypePayment = (brand?: string): boolean => {
+  return extractCollapsedTypeFromBrand(brand) !== undefined;
 };
 
 /**
- * Strips a wallet suffix (see extractWalletTypeFromBrand) to recover the underlying card brand,
- * e.g. "amex" from "amex_googlepay". Returns the brand unchanged if it carries no wallet suffix.
+ * Strips a wallet suffix (see extractCollapsedTypeFromBrand) to recover the underlying card brand,
+ * e.g. "amex" from "amex_googlepay". Returns the brand unchanged if it carries no such suffix, or
+ * if the suffix's brand has no underlying card brand to reveal (e.g. "bcmc").
  */
 export const extractCardBrand = (brand?: string): string | undefined => {
   if (!brand) {
     return brand;
   }
 
-  const suffix = Object.values(WALLET_BRAND_SUFFIXES).find((s) => brand.endsWith(s));
-  return suffix ? brand.slice(0, -suffix.length) : brand;
+  const pattern = Object.values(COLLAPSED_TYPE_BRAND_PATTERNS).find((p) => brand.endsWith(p.suffix));
+  return pattern?.revealsUnderlyingCardBrand ? brand.slice(0, -pattern.suffix.length) : brand;
 };
 
 const ADYEN_GIFT_CARD_BRAND_TO_CT_MAPPING: Record<string, string> = Object.fromEntries(

--- a/processor/src/services/converters/notification-recurring.converter.ts
+++ b/processor/src/services/converters/notification-recurring.converter.ts
@@ -17,7 +17,7 @@ import {
   convertAdyenCardBrandToCTFormat,
   convertPaymentMethodFromAdyenFormat,
   extractCardBrand,
-  extractWalletTypeFromBrand,
+  extractCollapsedTypeFromBrand,
 } from './helper.converter';
 import { AdyenApi } from '../../clients/adyen.client';
 import { getConfig } from '../../config/config';
@@ -101,12 +101,13 @@ export class NotificationTokenizationConverter {
     recurringTokenOperationData: RecurringTokenStoreOperation,
     storedPaymentMethodResource?: StoredPaymentMethodResource,
   ): Promise<string> {
-    // Adyen tokenizes wallet payments (e.g. Google Pay) as a generic "scheme" token, encoding the
-    // original wallet in the brand string instead (e.g. "amex_googlepay"). Prefer that so the
-    // shopper still sees "Google Pay" instead of a generic card.
-    const walletType = extractWalletTypeFromBrand(storedPaymentMethodResource?.brand);
-    if (walletType) {
-      return convertPaymentMethodFromAdyenFormat(walletType);
+    // Adyen tokenizes some payment methods (e.g. Google Pay, Bancontact card) as a generic
+    // "scheme" token, encoding the real payment method type in the brand string instead (e.g.
+    // "amex_googlepay", "bcmc"). Prefer that so the shopper still sees "Google Pay"/"Bancontact"
+    // instead of a generic card.
+    const collapsedType = extractCollapsedTypeFromBrand(storedPaymentMethodResource?.brand);
+    if (collapsedType) {
+      return convertPaymentMethodFromAdyenFormat(collapsedType);
     }
 
     if (!storedPaymentMethodResource || !storedPaymentMethodResource.type) {

--- a/processor/test/config/stored-payment-method.config.spec.ts
+++ b/processor/test/config/stored-payment-method.config.spec.ts
@@ -41,6 +41,14 @@ describe('stored-payment-methods.config', () => {
         oneOffPayments: false,
         recurringPayments: true,
       },
+      bcmc: {
+        oneOffPayments: false,
+        recurringPayments: true,
+      },
+      bcmc_mobile: {
+        oneOffPayments: false,
+        recurringPayments: true,
+      },
     });
   });
 });

--- a/processor/test/config/stored-payment-method.config.spec.ts
+++ b/processor/test/config/stored-payment-method.config.spec.ts
@@ -33,6 +33,14 @@ describe('stored-payment-methods.config', () => {
         recurringPayments: true,
         tokenizationAllowedCountries: ['AU', 'NZ'],
       },
+      bcmc: {
+        oneOffPayments: false,
+        recurringPayments: true,
+      },
+      bcmc_mobile: {
+        oneOffPayments: false,
+        recurringPayments: true,
+      },
     });
   });
 });

--- a/processor/test/routes.test/operations.spec.ts
+++ b/processor/test/routes.test/operations.spec.ts
@@ -133,6 +133,8 @@ describe('/operations APIs', () => {
           'klarna',
           'klarna_account',
           'afterpaytouch',
+          'bcmc',
+          'bcmc_mobile',
         ],
       });
     });

--- a/processor/test/services/adyen-payment.service.spec.ts
+++ b/processor/test/services/adyen-payment.service.spec.ts
@@ -1953,6 +1953,91 @@ describe('adyen-payment.service', () => {
       });
     });
 
+    test('should reclassify a Bancontact card token stale-recorded as a generic card, and only show it under recurring', async () => {
+      const merchantAccount = 'merchantAccount';
+      const customerId = '12303506-396c-4163-9193-11115c10fc2e';
+      const paymentInterface = 'adyen-payment-interface';
+      const interfaceAccount = 'adyen-interface-account';
+      const adyenToken = 'adyen-token-value-bcmc';
+
+      jest.spyOn(StoredPaymentMethodsConfig, 'getStoredPaymentMethodsConfig').mockReturnValue({
+        enabled: true,
+        config: {
+          paymentInterface,
+          interfaceAccount,
+          supportedPaymentMethodTypes: {
+            scheme: { oneOffPayments: true, recurringPayments: true },
+            bcmc: { oneOffPayments: false, recurringPayments: true },
+          },
+        },
+      });
+
+      const cartRandom = CartRest.random()
+        .lineItems([])
+        .customLineItems([])
+        .customerId(customerId)
+        .buildRest<TCartRest>({}) as Cart;
+
+      // Adyen collapses Bancontact card into a generic "scheme" token, encoding the real type in
+      // the brand ("bcmc") instead — mirroring how Google Pay encodes "amex_googlepay".
+      jest.spyOn(RecurringApi.prototype, 'getTokensForStoredPaymentDetails').mockResolvedValue({
+        merchantAccount,
+        shopperReference: customerId,
+        storedPaymentMethods: [
+          {
+            id: adyenToken,
+            type: 'scheme',
+            brand: 'bcmc',
+          },
+        ],
+      });
+      jest.spyOn(DefaultCartService.prototype, 'getCart').mockResolvedValue(cartRandom);
+      // The commercetools record was recorded as a generic "card" before Bancontact recurring
+      // was correctly classified (or before it was reclassified) — this must be corrected on read.
+      jest.spyOn(DefaultPaymentMethodService.prototype, 'find').mockResolvedValue({
+        count: 0,
+        limit: 100,
+        offset: 0,
+        results: [
+          {
+            id: 'd85435f2-2628-457f-8b8e-1a567da30a8d',
+            customer: { id: customerId, typeId: 'customer' },
+            token: { value: adyenToken },
+            paymentInterface,
+            interfaceAccount,
+            method: 'card',
+            createdAt: '',
+            lastModifiedAt: '',
+            default: false,
+            paymentMethodStatus: 'Active',
+            version: 1,
+          },
+        ],
+      });
+
+      const oneOffResult = await paymentService.getStoredPaymentMethods();
+      expect(oneOffResult).toStrictEqual({ storedPaymentMethods: [] });
+
+      const recurringResult = await paymentService.getStoredPaymentMethods({ withRecurring: true });
+      expect(recurringResult).toStrictEqual({
+        storedPaymentMethods: [
+          {
+            id: 'd85435f2-2628-457f-8b8e-1a567da30a8d',
+            createdAt: '',
+            isDefault: false,
+            token: adyenToken,
+            type: 'bancontactcard',
+            displayOptions: {
+              brand: { key: 'Bancontact' },
+              endDigits: undefined,
+              expiryMonth: undefined,
+              expiryYear: undefined,
+            },
+          },
+        ],
+      });
+    });
+
     test('should create a commercetools payment-method for an orphan Adyen token with default: false, without ever calling update()', async () => {
       const customerId = '12303506-396c-4163-9193-11115c10fc2e';
       const methodType = 'scheme';

--- a/processor/test/services/converters/create-payment.converter.spec.ts
+++ b/processor/test/services/converters/create-payment.converter.spec.ts
@@ -493,6 +493,8 @@ describe('create-payment.converter', () => {
     test.each([
       ['Klarna Pay Later', 'klarna'],
       ['Klarna Pay Over Time', 'klarna_account'],
+      ['Bancontact card', 'bcmc'],
+      ['Bancontact mobile', 'bcmc_mobile'],
     ])('it should force storePaymentMethod for a fresh %s payment on a recurring-cart', async (_label, adyenType) => {
       const customerId = '52a5774d-38c0-40b4-a2c6-512c5af6396e';
       const converter = new CreatePaymentConverter(paymentSDK.ctPaymentMethodService, paymentSDK.ctCartService);


### PR DESCRIPTION
This pull request introduces several improvements and refactors to how stored payment methods are handled and displayed in the dev-utils commercestore UI and backend processor. The main focus is on generalizing wallet and non-card payment method handling, improving recurring payment method support, and enhancing the UI for stored method management.

**UI and Display Improvements:**

* Replaced `WALLET_METHODS` with a new `METHOD_LABELS` and `METHODS_WITH_NO_CARDS` mapping in `method-labels.ts`, allowing consistent labeling and display handling for both wallet and non-card stored payment methods throughout the UI. [[1]](diffhunk://#diff-77d57918679f1acc3522f70e05e05ca48f6b8c4ed48e8810b40ce8a3340f9e70R1-R22) [[2]](diffhunk://#diff-5eefabde0bbe42ff521b79278523d03862a66cfb10fa71691e755f89d327198aL1-L10)
* Updated all components (`RecurringApp.tsx`, `ComponentsTab.tsx`, `useCheckout.ts`) to use `METHOD_LABELS` and `METHODS_WITH_NO_CARDS` for display logic, ensuring non-card methods like Klarna and Afterpay are correctly labeled and digits/expiry are only shown for card-backed methods. [[1]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0L7-R24) [[2]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0L23-R68) [[3]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fL4-R4) [[4]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fR38-R41) [[5]](diffhunk://#diff-0d17bd5e1e2efb91030119e6067baf5314a7b9b76102104b924ce6a9a4369e3fL50-R55) [[6]](diffhunk://#diff-20c4064e8534705ad283a13148fed463a8f70221c3e5b111039937e6f3b03480L4-R4) [[7]](diffhunk://#diff-20c4064e8534705ad283a13148fed463a8f70221c3e5b111039937e6f3b03480L80-R80)
* Added a "Remove" button to each recurring stored payment method in the UI, with proper loading state and error handling. [[1]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0L23-R68) [[2]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0R78-R89) [[3]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0L98-R128)

**API and Backend Enhancements:**

* Added a new API method, `deleteStoredPaymentMethod`, for deleting stored payment methods, and updated the recurring stored payment methods fetch endpoint to use the `withRecurring` query parameter. [[1]](diffhunk://#diff-b1a5dcf3ccaf0efb131a942c2e4ef624423b3586b841ccef016c870be9e041d0L7-R24) [[2]](diffhunk://#diff-cf165f87f4c8b4abc7465eb8dc7ba9bde63e2dc930f4770d03a46a9699f40b59L7-R7) [[3]](diffhunk://#diff-cf165f87f4c8b4abc7465eb8dc7ba9bde63e2dc930f4770d03a46a9699f40b59R21-R33)
* Extended the stored payment methods config to support more types (Klarna, Afterpay, Bancontact, etc.) and to restrict recurring/tokenization for certain methods to specific countries (e.g., Afterpay only in AU/NZ). [[1]](diffhunk://#diff-2b9544b51c1b78ba9b9840b8aa5252d714278248b475784df2a6443ebcb1376cR10-R13) [[2]](diffhunk://#diff-2b9544b51c1b78ba9b9840b8aa5252d714278248b475784df2a6443ebcb1376cR51-R75) [[3]](diffhunk://#diff-8a4953c43c2fe43c09c9b48cfdd054369bd58b0a560add2391be7e5d01b7e852L223-R229) [[4]](diffhunk://#diff-8a4953c43c2fe43c09c9b48cfdd054369bd58b0a560add2391be7e5d01b7e852R295-R306)

**Backend Logic Refactor:**

* Refactored Adyen token handling to generalize "collapsed" payment method types (e.g., Google Pay, Bancontact, Klarna) instead of only wallet types, improving detection and correct assignment of stored payment method types. [[1]](diffhunk://#diff-6d406fe8ec80e408fadfcbf75214a060c7e2441e2e51d6a1478be03dd8c0b5a4L98-L100) [[2]](diffhunk://#diff-6d406fe8ec80e408fadfcbf75214a060c7e2441e2e51d6a1478be03dd8c0b5a4L1222-R1229) [[3]](diffhunk://#diff-6d406fe8ec80e408fadfcbf75214a060c7e2441e2e51d6a1478be03dd8c0b5a4L1248-R1255)

**Other Improvements:**

* Updated navigation URLs in the return flow to point to the correct dev-utils commercestore pages.
* Improved the main dev site landing page with a link to the refactored commercestore for better developer guidance.

These changes together make stored payment method handling more robust, extensible, and user-friendly, especially for non-card and region-specific payment methods.